### PR TITLE
Updates to the taxon, genome_annotation methods, move type checks to constructor

### DIFF
--- a/bin/data_api_demo.py
+++ b/bin/data_api_demo.py
@@ -24,35 +24,35 @@ if __name__ == "__main__":
     
     print "object_api = biokbase.data_api.object.ObjectAPI()"
     object_api = biokbase.data_api.object.ObjectAPI(services, ref="testCondensedGenomeV2/GENOME_ANNOTATION_Escherichia_coli_K12")
-    
-    print "\n\nobject_api.get_schema()"
-    pprint.pprint(object_api.get_schema())
-    
+
+    print "Pull back basic object info for any object type:"
     print "\n\nobject_api.get_typestring()"
     pprint.pprint(object_api.get_typestring())
     
     print "\n\nobject_api.get_info()"
     pprint.pprint(object_api.get_info())
-    
-    print "\n\nobject_api.get_history()"
-    pprint.pprint(object_api.get_history())
-    
-    print "\n\nobject_api.get_provenance()"
-    pprint.pprint(object_api.get_provenance())
-    
+
     print "\n\nobject_api.get_id()"
     pprint.pprint(object_api.get_id())
     
     print "\n\nobject_api.get_name()"
     pprint.pprint(object_api.get_name())
     
-    print "\n\nobject_api.get_stats()"
-    pprint.pprint(object_api.get_stats())
+    print "\n\nobject_api.get_history()"
+    pprint.pprint(object_api.get_history())
     
-    print "\n\nobject_api.get_data()"
+    print "\n\nobject_api.get_provenance()"
+    pprint.pprint(object_api.get_provenance())
+
+    print "\n\nobject_api.get_schema()"
+    pprint.pprint(object_api.get_schema())
+            
+    print "\n\nFetch the full JSON document for this object:"
+    print "object_api.get_data()"
     pprint.pprint(object_api.get_data())
     
-    print "\n\nobject_api.get_data_subset([\"domain\"])"
+    print "\n\nFetch specific pieces of an object by path strings:"
+    print "object_api.get_data_subset([\"domain\"])"
     pprint.pprint(object_api.get_data_subset(["domain"]))
     
 
@@ -61,23 +61,30 @@ if __name__ == "__main__":
     print "assembly_api = biokbase.data_api.assembly.AssemblyAPI()"
     assembly_api = biokbase.data_api.assembly.AssemblyAPI(services, ref="testCondensedGenomeV2/kb|g.0_assembly")
     
-    print "\n\nassembly_api.get_assembly_id()"
+    print "\n\nFetch basic info for an Assembly:"
+    print "assembly_api.get_assembly_id()"
     pprint.pprint(assembly_api.get_assembly_id())
-    
-    print "\n\nassembly_api.get_external_source_info()"
-    pprint.pprint(assembly_api.get_external_source_info())
-    
-    print "\n\nassembly_api.get_stats()"
+        
+    print "\nassembly_api.get_stats()"
     pprint.pprint(assembly_api.get_stats())
     
-    print "\n\nassembly_api.get_number_contigs()"
+    print "\nassembly_api.get_number_contigs()"
     pprint.pprint(assembly_api.get_number_contigs())
+
+    print "\nFetch the information telling me about where this Assembly came from:"
+    print "assembly_api.get_external_source_info()"
     
-    print "\n\nassembly_api.get_contig_ids()"
+    pprint.pprint(assembly_api.get_external_source_info())
+
+    print "\nFetch the contig ids:"    
+    print "contig_ids = assembly_api.get_contig_ids()"
+    print "pprint.pprint(contig_ids)"
+    
     contig_ids = assembly_api.get_contig_ids()
     pprint.pprint(contig_ids)
-    
-    print "\n\nassembly_api.get_contigs_by_id()"
+
+    print "\nUse the contig ids to fetch the contig sequences and metadata:"
+    print "assembly_api.get_contigs_by_id([contig_ids[0]])"
     contigs = assembly_api.get_contigs_by_id([contig_ids[0]])
     pprint.pprint(contigs)
 
@@ -87,77 +94,104 @@ if __name__ == "__main__":
     print "genome_annotation_api = biokbase.data_api.genome_annotation.GenomeAnnotationAPI()"
     genome_annotation_api = biokbase.data_api.genome_annotation.GenomeAnnotationAPI(services, ref="testCondensedGenomeV2/GENOME_ANNOTATION_Escherichia_coli_K12")
     
-    print "\n\ngenome_annotation_api.get_taxon_ref()"
-    taxon_ref = genome_annotation_api.get_taxon_ref()
-    pprint.pprint(taxon_ref)
+    print "\n\nGet my connected Taxon:"
+    print "genome_annotation_api.get_taxon()"
+    print "# there is a data reference error here, the taxon ref for this genome annotation is incorrect and points to wheat"
+    taxon_api = genome_annotation_api.get_taxon()
+    pprint.pprint(taxon_api)
     
-    print "\n\ngenome_annotation_api.get_assembly_ref()"
-    assembly_ref = genome_annotation_api.get_assembly_ref()
-    pprint.pprint(assembly_ref)
-    
-    print "\n\ngenome_annotation_api.get_feature_types()"
+    print "\nGet the Assembly connected to this Genome Annotation:"
+    print "genome_annotation_api.get_assembly()"
+    assembly_api = genome_annotation_api.get_assembly()
+    pprint.pprint(assembly_api)
+
+    print "\nShow me what feature types are contained in this Genome Annotation:"    
+    print "genome_annotation_api.get_feature_types()"
     feature_types = genome_annotation_api.get_feature_types()
     pprint.pprint(feature_types)
     
-    print "\n\ngenome_annotation_api.get_feature_ids_by_type(['{0}'])".format(feature_types[0])
-    pprint.pprint(genome_annotation_api.get_feature_ids_by_type([feature_types[0]]))
+    print "\nDescribe these feature types for me:"
+    print "pprint.pprint(genome_annotation_api.get_feature_type_descriptions(feature_types))"
+    pprint.pprint(genome_annotation_api.get_feature_type_descriptions(feature_types))
     
-    print "\n\ngenome_annotation_api.get_feature_ids_by_region(contig_id_list=['{0}'],type_list=['{1}'])".format(contig_ids[0],feature_types[0])
-    pprint.pprint(genome_annotation_api.get_feature_ids_by_region(contig_id_list=[contig_ids[0]], type_list=[feature_types[0]]))
+    print "\nHmm, Terminators...let's see more about those:"
+    print "genome_annotation_api.get_feature_ids_by_type(['{0}'])".format(feature_types[0])
+    feature_ids = genome_annotation_api.get_feature_ids_by_type([feature_types[0]])
+    pprint.pprint(feature_ids)
     
-    print "\n\ngenome_annotation_api.get_feature_ids_by_function()"
-    pprint.pprint(genome_annotation_api.get_feature_ids_by_function())
+    #print "genome_annotation_api.get_feature_ids_by_region(contig_id_list=['{0}'],type_list=['{1}'])".format(contig_ids[0],feature_types[0])
+    #pprint.pprint(genome_annotation_api.get_feature_ids_by_region(contig_id_list=[contig_ids[0]], type_list=[feature_types[0]]))
     
-    print "\n\ngenome_annotation_api.get_feature_ids_by_alias()"
-    pprint.pprint(genome_annotation_api.get_feature_ids_by_alias())
+    #print "\n\ngenome_annotation_api.get_feature_ids_by_function(['gene'])"
+    #pprint.pprint(genome_annotation_api.get_feature_ids_by_function(['gene']))
     
-    print "\n\ngenome_annotation_api.get_associated_feature_ids()"
-    pprint.pprint(genome_annotation_api.get_associated_feature_ids())
+    #print "\n\ngenome_annotation_api.get_feature_ids_by_alias()"
+    #pprint.pprint(genome_annotation_api.get_feature_ids_by_alias())
     
-    print "\n\ngenome_annotation_api.get_child_feature_ids()"
-    pprint.pprint(genome_annotation_api.get_child_feature_ids())
+    #print "\n\ngenome_annotation_api.get_associated_feature_ids()"
+    #pprint.pprint(genome_annotation_api.get_associated_feature_ids())
     
-    print "\n\ngenome_annotation_api.get_parent_feature_ids()"
-    pprint.pprint(genome_annotation_api.get_parent_feature_ids())
+    #print "\n\ngenome_annotation_api.get_child_feature_ids()"
+    #pprint.pprint(genome_annotation_api.get_child_feature_ids())
     
-    print "\n\ngenome_annotation_api.get_protein_ids_by_cds()"
-    pprint.pprint(genome_annotation_api.get_protein_ids_by_cds())
+    #print "\n\ngenome_annotation_api.get_parent_feature_ids()"
+    #pprint.pprint(genome_annotation_api.get_parent_feature_ids())
     
-    print "\n\ngenome_annotation_api.get_features_by_id()"
-    pprint.pprint(genome_annotation_api.get_features_by_id())
+    #print "\n\ngenome_annotation_api.get_protein_ids_by_cds()"
+    #pprint.pprint(genome_annotation_api.get_protein_ids_by_cds())
     
-    print "\n\ngenome_annotation_api.get_proteins()"
-    pprint.pprint(genome_annotation_api.get_proteins())
+    print "\ngenome_annotation_api.get_features_by_id(feature_ids)"
+    pprint.pprint(genome_annotation_api.get_features_by_id(feature_ids))
+    
+    #print "\n\ngenome_annotation_api.get_proteins()"
+    #pprint.pprint(genome_annotation_api.get_proteins())
     
     
     print "\n\nTaxon API methods for E.coli K12"
     
-    print "taxon_api = biokbase.data_api.taxon.TaxonAPI()"
-    taxon_api = biokbase.data_api.taxon.TaxonAPI(services, ref=taxon_ref)
+    print "taxon_api = biokbase.data_api.taxon.TaxonAPI(services, ref='Taxon3/83333_taxon')"
+    taxon_api = biokbase.data_api.taxon.TaxonAPI(services, ref="Taxon3/83333_taxon")
+
+    print "\n\nPull back my taxonomy information:"        
+    print "taxon_api.get_scientific_lineage()"
+    pprint.pprint(taxon_api.get_scientific_lineage())
     
-    print "\n\ntaxon_api.get_parent()"
-    pprint.pprint(taxon_api.get_parent())
-    
-    print "\n\ntaxon_api.get_children()"
-    pprint.pprint(taxon_api.get_children())
-    
-    print "\n\ntaxon_api.get_genome_annotations()"
-    pprint.pprint(taxon_api.get_genome_annotations())
-    
-    print "\n\ntaxon_api.get_taxonomic_lineage()"
-    pprint.pprint(taxon_api.get_taxonomic_lineage())
-    
-    print "\n\ntaxon_api.get_scientific_name()"
+    print "\ntaxon_api.get_scientific_name()"
     pprint.pprint(taxon_api.get_scientific_name())
     
-    print "\n\ntaxon_api.get_taxonomic_id()"
+    print "\ntaxon_api.get_taxonomic_id()"
     pprint.pprint(taxon_api.get_taxonomic_id())
     
-    print "\n\ntaxon_api.get_domain()"
+    print "\ntaxon_api.get_domain()"
     pprint.pprint(taxon_api.get_domain())
     
-    print "\n\ntaxon_api.get_aliases()"
+    print "\ntaxon_api.get_aliases()"
     pprint.pprint(taxon_api.get_aliases())
     
-    print "\n\ntaxon_api.get_genetic_code()"
+    print "\ntaxon_api.get_genetic_code()"
     pprint.pprint(taxon_api.get_genetic_code())
+
+    print "\nTrace back up the Taxon lineage using get_parent() and get scientific name and ncbi tax id:"
+    print "parent = taxon_api.get_parent()"
+    print "while parent:"
+    print "    pprint.pprint([parent.get_scientific_name(),parent.get_taxonomic_id()])"
+    print "    parent = parent.get_parent()\n"
+    
+    parent = taxon_api.get_parent()
+    while parent:
+        pprint.pprint([parent.get_scientific_name(),parent.get_taxonomic_id()])
+        parent = parent.get_parent()
+    
+    print "\nFind out what other E.Coli there are using get_parent() and get_children():"
+    print "#Causing timeout problems, need to investigate more"
+    print "parent = taxon_api.get_parent()"
+    print "sibling_info = [(s.get_scientific_name(), s.get_taxonomic_id()) for s in parent.get_children()]"
+    print "pprint.pprint(sibling_info)\n"
+    
+    parent = taxon_api.get_parent()
+    sibling_info = [(s.get_scientific_name(), s.get_taxonomic_id()) for s in parent.get_children()]
+    pprint.pprint(sibling_info)
+
+    print "\nFind out what Genome Annotations reference my Taxon:"        
+    print "taxon_api.get_genome_annotations()"
+    pprint.pprint(taxon_api.get_genome_annotations())

--- a/lib/biokbase/data_api/assembly.py
+++ b/lib/biokbase/data_api/assembly.py
@@ -2,12 +2,8 @@
 Operations on Assembly data type.
 """
 import requests
-import sys
 import os
-import json
-import datetime
 import re
-import shutil
 import string
 
 try:

--- a/lib/biokbase/data_api/assembly.py
+++ b/lib/biokbase/data_api/assembly.py
@@ -35,6 +35,10 @@ class AssemblyAPI(ObjectAPI):
         
         self._is_assembly_type = self._typestring in self._assembly_types
         self._is_contigset_type = self._typestring in self._contigset_types
+        
+        if not (self._is_assembly_type or self._is_contigset_type):
+            raise TypeError("Invalid type! Expected KBaseGenomes.ContigSet or KBaseGenomesCondensedPrototype.Assembly, received " + info[2])
+            
 
     def get_assembly_id(self):
         """
@@ -155,8 +159,6 @@ class AssemblyAPI(ObjectAPI):
         elif self._is_assembly_type:
             contigs = self.get_data()["contigs"]
             return [contigs[c]["contig_id"] for c in contigs]
-        else:
-            raise TypeError("Invalid type! Expected KBaseGenomes.ContigSet <= 3.0 or KBaseGenomesCondensedPrototype.Assembly <= 1.0, received " + info[2])
 
     def get_contigs_by_id(self, contig_id_list=list()):
         """
@@ -269,5 +271,3 @@ class AssemblyAPI(ObjectAPI):
                     outContigs[c]["sequence"] = fetch_contig(contigs[c]["start_position"],contigs[c]["num_bytes"])
 
             return outContigs
-        else:
-            raise TypeError("Invalid type! Expected KBaseGenomes.ContigSet <= 3.0 or KBaseGenomesCondensedPrototype.Assembly <= 1.0, received " + info[2])

--- a/lib/biokbase/data_api/genome_annotation.py
+++ b/lib/biokbase/data_api/genome_annotation.py
@@ -2,6 +2,28 @@ import sys
 
 from biokbase.data_api.object import ObjectAPI
 
+FEATURE_DESCRIPTIONS = {
+    "CDS": "Coding Sequence",
+    "PEG": "Protein Encoding Genes",
+    "rna": "RNA",
+    "crispr": "Clustered Regularly Interspaced Short Palindromic Repeats",
+    "crs": "Clustered Regularly Interspaced Short Palindromic Repeats",
+    "mRNA": "Messenger RNA",
+    "sRNA": "Small RNA",
+    "loci": "Loci",
+    "opr": "Operons",
+    "pbs": "Protein Binding Site",
+    "bs": "Binding Site",
+    "pseudo": "PseudoGenes",
+    "att": "Attenuator",
+    "prm": "Promoter",
+    "trm": "Terminator",
+    "pp": "Prophage",
+    "pi": "Pathogenicity Island",
+    "rsw": "Riboswitch",
+    "trnspn": "Transposon"    
+}
+
 class GenomeAnnotationAPI(ObjectAPI):
     def __init__(self, services, ref):
         """
@@ -23,20 +45,39 @@ class GenomeAnnotationAPI(ObjectAPI):
         
         self._is_annotation_type = self._typestring in self._annotation_types
         self._is_genome_type = self._typestring in self._genome_types
+        
+        if not (self._is_annotation_type or self._is_genome_type):
+            raise TypeError("Expecting KBaseGenomes.Genome or KBaseGenomesCondensedPrototypeV2.GenomeAnnotation, received {0}".format(self._typestring))
 
-    def get_taxon_ref(self):
+    def get_taxon(self):
+        """
+        Retrieves the Taxon assigned to this Genome Annotation.
+        
+        Returns:
+            TaxonAPI
+        """
+        
+        import biokbase.data_api.taxon
+        
         if self._is_genome_type:
-            return self.ref        
+            return biokbase.data_api.taxon.TaxonAPI(self.services, ref=self.ref)
         elif self._is_annotation_type:
-            return self.get_data_subset(path_list=["taxon_ref"])["taxon_ref"]        
+            return biokbase.data_api.taxon.TaxonAPI(self.services, ref=self.get_data_subset(path_list=["taxon_ref"])["taxon_ref"])
 
-    def get_assembly_ref(self):
-        typestring = self.get_typestring()
-
-        if typestring in self._genome_types:
-            return self.get_data_subset(path_list=["contigset_ref"])["contigset_ref"]
-        elif typestring in self._annotation_types:
-            return self.get_data_subset(path_list=["assembly_ref"])["assembly_ref"]        
+    def get_assembly(self):
+        """
+        Retrieves the Assembly used to create this Genome Annotation.
+        
+        Returns:
+            AssemblyAPI
+        """
+        
+        import biokbase.data_api.assembly
+        
+        if self._is_genome_type:
+            return biokbase.data_api.assembly.AssemblyAPI(self.services, ref=self.get_data_subset(path_list=["contigset_ref"])["contigset_ref"])
+        elif self._is_annotation_type:
+            return biokbase.data_api.assembly.AssemblyAPI(self.services, ref=self.get_data_subset(path_list=["assembly_ref"])["assembly_ref"])
     
     def get_feature_types(self):
         if self._is_genome_type:
@@ -48,6 +89,30 @@ class GenomeAnnotationAPI(ObjectAPI):
             return feature_types
         elif self._is_annotation_type:
             return self.get_data_subset(path_list=["feature_container_references"])["feature_container_references"].keys()
+
+    def get_feature_type_descriptions(self, type_list=None):
+        if type_list == None:
+            return FEATURE_DESCRIPTIONS
+        elif type(type_list) == type([]) and len(type_list) and \
+             (type(type_list[0]) == type(u"") or type(type_list[0]) == type("")):
+            return {x: FEATURE_DESCRIPTIONS[x] for x in FEATURE_DESCRIPTIONS if x in type_list}
+
+    def get_number_of_each_feature_type(self):
+        if self._is_genome_type:
+            features = self.get_data_subset(path_list=["features"])["features"]
+            feature_types = dict()
+            for x in features:
+                if x["type"] not in feature_types:
+                    feature_types[x["type"]] = 1
+                else:
+                    feature_types[x["type"]] += 1
+            return feature_types
+        elif self._is_annotation_type:            
+            feature_container_refs = self.get_data_subset(path_list=["feature_container_references"])["feature_container_references"]
+            feature_types = dict()
+            for x in feature_container_refs:
+                feature_types[x] = len(ObjectAPI(self.services, ref=feature_container_refs[x]).get_data()["features"])
+            return feature_types            
 
     def get_feature_ids(self):
         if self._is_genome_type:
@@ -62,6 +127,30 @@ class GenomeAnnotationAPI(ObjectAPI):
                 out_ids[x].extend(feature_container.get_data()["features"].keys())
             return out_ids
 
+    def _genome_get_features_by_type(self, type_list=None, test=lambda x: True):
+        features = self.get_data()["features"]
+        print features
+        #["features"]
+        
+        out_features = dict()            
+        for x in features:
+            out_features[x] = list()
+            if x['type'] in type_list and test(x):
+                if x['type'] not in out_features:
+                    out_features[x['type']] = list()
+                
+                out_features[x['type']].append(x)
+        return out_features
+
+    def _annotation_get_features_by_type(self, type_list=None, test=lambda x: True):
+        feature_container_references = self.get_data_subset(path_list=["feature_container_references"])["feature_container_references"]
+        
+        out_ids = dict()                        
+        for x in [k for k in feature_container_references if k in type_list]:
+            feature_container = ObjectAPI(services=self.services, ref=feature_container_references[x])
+            out_features[x] = [x for x in feature_container.get_data()["features"] if test(x)]
+        return out_features
+
     def _genome_get_feature_ids_by_type(self, type_list=None, test=lambda x: True):
         features = self.get_data_subset(path_list=["features"])["features"]
         
@@ -69,8 +158,7 @@ class GenomeAnnotationAPI(ObjectAPI):
         for x in features:
             out_ids[x] = list()
             if x['type'] in type_list and test(x):
-                out_ids[x['type']].append(x['id'])
-            
+                out_ids[x['type']].append(x['id'])            
         return out_ids
 
     def _annotation_get_feature_ids_by_type(self, type_list=None, test=lambda x: True):
@@ -119,38 +207,53 @@ class GenomeAnnotationAPI(ObjectAPI):
                 return False
         
         if self._is_genome_type:                            
-            return self._genome_get_feature_ids_by_type(type_list, is_feature_in_region)
+            return self._genome_get_feature_ids_by_type(type_list, lambda x: is_feature_in_region(x))
         elif self._is_annotation_type:
-            return self._annotation_get_feature_ids_by_type(type_list, is_feature_in_region)
+            return self._annotation_get_feature_ids_by_type(type_list, lambda x: is_feature_in_region(x))
 
     def get_feature_ids_by_function(self, function_list=None, type_list=None):
+        if function_list == None:
+            raise TypeError("A list of feature function strings is required.")
+        elif len(function_list) == 0:
+            raise TypeError("A list of feature function strings is required, recieved an empty list.")
+        
+        if type_list == None:        
+            type_list = self.get_feature_types()
+        
         function_tokens = list()
         for x in function_list:
             function_tokens.extend(x.split())
         function_tokens = set(function_tokens)
         
-        def is_function_in_feature(f):
-            tokens = f.split()            
+        def is_function_in_feature(feature, function_tokens=function_tokens):
+            tokens = feature['function'].split()            
             
+            found = False
             for t in tokens:
                 if t in function_tokens:
-                    return True
-                else:
-                    return False
+                    found = True
+                    break
+            return found
                 
         if self._is_genome_type:
             out_ids = dict()
-            for f in function_list:
-                features = self._genome_get_feature_ids_by_type(type_list, is_function_in_feature)
-                if features:
-                    out_ids.extend([x['id'] for x in features])
+            for function in function_list:
+                features = self._genome_get_features_by_type(type_list, lambda x: is_function_in_feature(x))
+                for feature_type in features:
+                    if feature_type not in out_ids:
+                        out_ids[feature_type] = [x['id'] for x in features[feature_type]]
+                    else:
+                        out_ids[feature_type].extend([x['id'] for x in features[feature_type]])
             return out_ids
         elif self._is_annotation_type:
             out_ids = dict()
-            for f in function_list:
-                features = self._annotation_get_feature_ids_by_type(type_list, is_function_in_feature)
-                if features:
-                    out_ids.extend([x['feature_id'] for x in features])
+            for function in function_list:
+                features = self._annotation_get_features_by_type(type_list, lambda x: is_function_in_feature(function, x))
+                for feature_type in features:
+                    if feature_type not in out_ids:
+                        out_ids[feature_type] = [x['feature_id'] for x in features[feature_type]]
+                    else:
+                        out_ids[feature_type].extend([x['feature_id'] for x in features[feature_type]])
             return out_ids
 
     def get_feature_ids_by_alias(self, alias_list=None, type=None):
@@ -171,6 +274,7 @@ class GenomeAnnotationAPI(ObjectAPI):
             for x in [k for k in feature_container_references if k in type_list]:
                 feature_container = ObjectAPI(self.services, feature_container_references[x])
                 out_ids[x] = feature_container.get_data()["features"].keys()
+            return out_ids
 
     def get_associated_feature_ids(self, from_type=None, to_type=None, feature_id_list=None):
         raise NotImplementedError
@@ -185,7 +289,26 @@ class GenomeAnnotationAPI(ObjectAPI):
         raise NotImplementedError
 
     def get_features_by_id(self, feature_id_list=None):
-        raise NotImplementedError
+        if self._is_genome_type:
+            features = self.get_data_subset(path_list=["features"])["features"]
+            
+            out_features = dict()            
+            for x in features:
+                if x['id'] in feature_id_list:
+                    out_features[x['id']] = x
+                
+            return out_features
+        elif self._is_annotation_type:
+            feature_container_references = self.get_data_subset(path_list=["feature_container_references"])["feature_container_references"]
+            
+            out_features = dict()                        
+            for x in feature_container_references:
+                feature_container = ObjectAPI(self.services, feature_container_references[x])
+                features = feature_container.get_data()["features"]
+                for f in features:
+                    if f in feature_id_list:
+                        out_features[f] = features[f]
+            return out_features
 
     def get_proteins(self):
         if self._is_genome_type:

--- a/lib/biokbase/data_api/genome_annotation.py
+++ b/lib/biokbase/data_api/genome_annotation.py
@@ -1,22 +1,6 @@
-import requests
 import sys
-import os
-import json
-import datetime
-import re
-import tempfile
-import shutil
-import string
-
-try:
-    import cStringIO as StringIO
-except ImportError:
-    import StringIO as StringIO
 
 from biokbase.data_api.object import ObjectAPI
-
-CHUNK_SIZE = 2**30
-
 
 class GenomeAnnotationAPI(ObjectAPI):
     def __init__(self, services, ref):

--- a/lib/biokbase/data_api/object.py
+++ b/lib/biokbase/data_api/object.py
@@ -8,7 +8,7 @@ except ImportError:
 from biokbase.data_api import _get_token as get_token
 import biokbase.workspace.client
 
-REF_PATTERN = re.compile(".+/.+(/[0-9].+)?")
+REF_PATTERN = re.compile("(.+/.+(/[0-9].+)?)|(ws\.[1-9][0-9]+\.[1-9][0-9]+)")
 
 class ObjectAPI(object):
     """
@@ -32,31 +32,53 @@ class ObjectAPI(object):
         self.ws_client = biokbase.workspace.client.Workspace(services["workspace_service_url"], token=get_token())
         self.ref = ref
         
-        self._info = self.ws_client.get_object_info_new({
+        info_values = self.ws_client.get_object_info_new({
             "objects": [{"ref": self.ref}],
             "includeMetadata": 0,
-            "ignoreErrors": 0})[0]
-        self._id = self._info[0]
-        self._name = self._info[1]
-        self._typestring = self.ws_client.translate_to_MD5_types([self._info[2]]).values()[0]
+            "ignoreErrors": 0})[0]        
+        
+        self._info = {
+            "object_id": info_values[0],
+            "object_name": info_values[1],
+            "object_reference": "{0}/{1}".format(info_values[6],info_values[0]),
+            "object_reference_versioned": "{0}/{1}/{2}".format(info_values[6],info_values[0],info_values[4]),
+            "type_string": info_values[2],
+            "save_date": info_values[3],
+            "version": info_values[4],
+            "saved_by": info_values[5],
+            "workspace_id": info_values[6],
+            "workspace_name": info_values[7],
+            "object_checksum": info_values[8],
+            "object_size": info_values[9],
+            "object_metadata": info_values[10]
+        }
+        self._id = self._info["object_id"]
+        self._name = self._info["object_name"]
+        self._typestring = self.ws_client.translate_to_MD5_types([self._info["type_string"]]).values()[0]
+        self._version = self._info["version"]
+        self._schema = None
+        self._history = None
+        self._provenance = None
+        self._data = None
 
     def get_schema(self):
         """
         Retrieve the schema associated with this object.
         
         Returns:
-            string
-        """
+          string"""
     
-        return self.ws_client.get_type_info(self.get_info()[2])
+        if self._schema == None:
+            self._schema = self.ws_client.get_type_info(self.get_info()["type_string"])
+        
+        return self._schema
 
     def get_typestring(self):
         """
         Retrieve the type identifier string.
         
         Returns:
-            string
-        """
+          string"""
                 
         return self._typestring
 
@@ -65,8 +87,7 @@ class ObjectAPI(object):
         Retrieve basic properties about this object.
         
         Returns:
-            dict
-        """
+          dict"""
             
         return self._info
 
@@ -74,23 +95,28 @@ class ObjectAPI(object):
         """
         Retrieve the recorded history of this object describing how it has been modified.
         """
-    
-        return self.ws_client.get_object_history({"ref": self.ref})
+        
+        if self._history == None:
+            self._history = self.ws_client.get_object_history({"ref": self.ref})
+        
+        return self._history
     
     def get_provenance(self):
         """
         Retrieve the recorded provenance of this object describing how to recreate it.
         """
-    
-        return self.ws_client.get_object_provenance([{"ref": self.ref}])
+        
+        if self._provenance == None:
+            self._provenance = self.ws_client.get_object_provenance([{"ref": self.ref}])
+        
+        return self._provenance
     
     def get_id(self):
         """
         Retrieve the internal identifier for this object.
         
         Returns:
-            string
-        """
+          string"""
     
         return self._id
     
@@ -99,38 +125,50 @@ class ObjectAPI(object):
         Retrieve the name assigned to this object.
         
         Returns:
-            string
-        """
+          string"""
     
         return self._name
     
-    def get_stats(self):
-        """
-        Retrieve any derived statistical information known about this object.
-        """
-    
-        return self._info
-
     def get_data(self):
         """
         Retrieve object data.
         
         Returns:
-            dict
-        """
+          dict"""
         
-        return self.ws_client.get_objects([{"ref": self.ref}])[0]["data"]
+        if self._data == None:
+            self._data = self.ws_client.get_objects([{"ref": self.ref}])[0]["data"]
+        
+        return self._data
 
     def get_data_subset(self, path_list=None):
         """
         Retrieve a subset of data from this object, given a list of paths to the data elements.
         
         Returns:
-            dict
-        """
-    
+          dict"""
+
         return self.ws_client.get_object_subset([{"ref": self.ref, 
                         "included": path_list}])[0]["data"]
+    
+    def get_referrers(self):
+        """
+        Retrieve a dictionary that indicates by type what objects are referring to this object.
+        
+        Returns:
+          dict"""
+        
+        referrers = self.ws_client.list_referencing_objects([{"ref": self.ref}])[0]
+        
+        object_refs_by_type = dict()        
+        for x in referrers:
+            typestring = self.ws_client.translate_to_MD5_types([x[2]]).values()[0]
+            
+            if typestring not in object_refs_by_type:
+                object_refs_by_type[typestring] = list()
+            
+            object_refs_by_type[typestring].append(str(x[6]) + "/" + str(x[0]) + "/" + str(x[4]))
+        return object_refs_by_type
     
     def copy(self, to_ws=None):
         """
@@ -141,9 +179,8 @@ class ObjectAPI(object):
         or referenced objects.
         
         Args:
-            to_ws : the target workspace to copy the object to, which the user must have permission
-            to write to.        
-        """
+          to_ws : the target workspace to copy the object to, which the user must have permission
+          to write to."""
     
         name = self.get_name()
         

--- a/lib/biokbase/data_api/object.py
+++ b/lib/biokbase/data_api/object.py
@@ -1,11 +1,4 @@
-import requests
-import sys
-import json
-import datetime
 import re
-import tempfile
-import shutil
-import string
 
 try:
     import cStringIO as StringIO

--- a/lib/biokbase/data_api/taxon.py
+++ b/lib/biokbase/data_api/taxon.py
@@ -1,10 +1,16 @@
 from biokbase.data_api.object import ObjectAPI
 
 class TaxonAPI(ObjectAPI):
+    """
+    Represents a Taxonomic Unit, e.g., species.
+    Built to support KBaseGenomesCondensedPrototypeV2.Taxon and KBaseGenomes.Genome.
+    """    
+    
     def __init__(self, services, ref):
         """
         Defines which types and type versions that are legal.
         """
+        
         super(TaxonAPI, self).__init__(services, ref)
         
         self._genome_types = ['KBaseGenomes.Genome-225de07e59f4fdc5d9b8bf0bcd12c498', 
@@ -17,39 +23,145 @@ class TaxonAPI(ObjectAPI):
         self._taxon_types = ['KBaseGenomesCondensedPrototypeV2.Taxon-ba7d1e3c906dba5b760e22f5d3bba2a2', 
                              'KBaseGenomesCondensedPrototypeV2.Taxon-f569f539547dd1eea6a59eb9aa0b2eda']
 
+        self._is_genome_type = self._typestring in self._genome_types
+        self._is_taxon_type = self._typestring in self._taxon_types
+        
+        if not (self._is_genome_type or self._is_taxon_type):
+            raise TypeError("Invalid type! Expected KBaseGenomes.Genome or KBaseGenomesCondensedPrototypeV2.Taxon, received {0}".format(self._typestring))
+    
     def get_parent(self):
-        typestring = self.get_typestring()
+        """
+        Retrieve parent Taxon of this Taxon as a TaxonAPI object.
+        If this is accessing a Genome object, returns None.
         
-        if typestring in self._taxon_types:
-            return self.get_data()["parent"]
-        elif typestrig in self._genome_types:
-            return NotImplementedError
+        Returns:
+          TaxonAPI"""
         
-    def get_children(self, ref_list=None):
-        raise NotImplementedError
+        if self._is_taxon_type:
+            try:
+                parent_ref = self.get_data()["parent_taxon_ref"]
+            except KeyError:
+                return None
+            
+            return TaxonAPI(self.services, ref=parent_ref)
+        elif self._is_genome_type:
+            return None
+        
+    def get_children(self):
+        """
+        Retrieve the children Taxon of this Taxon as TaxonAPI objects.
+        If this is accessing a Genome object, returns None.
+        
+        Returns:
+          list<TaxonAPI>"""
+        
+        if self._is_taxon_type:
+            referrers = self.get_referrers()
+            children = [TaxonAPI(self.services, ref=y) for y in referrers[x] for x in referrers if x in self._taxon_types]
+            
+            if len(children) == 0:
+                return None
+        elif self._is_genome_type:
+            return None
+        
+    def get_genome_annotations(self):
+        """
+        Retrieve the GenomeAnnotations that refer to this Taxon.
+        If this is accessing a Genome object, returns None.
+        
+        Returns:
+          list<GenomeAnnotationAPI>"""
+        
+        if self._is_taxon_type:
+            import biokbase.data_api.genome_annotation            
+            
+            referrers = self.get_referrers()
+            annotations = [biokbase.data_api.genome_annotation.GenomeAPI(self.services, ref=referrers[x]) \
+                           for x in referrers if x.startswith("KBaseGenomesCondensedPrototypeV2.GenomeAnnotation")]
+            
+            if len(annotations) == 0:
+                return None
+        elif self._is_genome_type:
+            return None
+
+    def get_scientific_lineage(self):
+        """
+        Retrieve the scientific lineage of this Taxon.
+        
+        Returns:
+          str
+        
+          e.g., "Top unit;Middle unit;Lowest unit" """
+        
+        if self._is_genome_type:
+            return self.get_data_subset(["taxonomy"])["taxonomy"]
+        elif self._is_taxon_type:
+            return self.get_data()["scientific_lineage"]
     
-    #use list_referencing_objects
-    def get_genome_annotations(self, ref_list=None):
-        raise NotImplementedError
+    def get_scientific_name(self):
+        """
+        Retrieve the scientific name of this Taxon.
+        
+        Returns:
+          str
+            
+          e.g., Escherichia Coli K12 str. MG1655"""
+        
+        if self._is_genome_type:
+            return self.get_data_subset(["scientific_name"])["scientific_name"]
+        elif self._is_taxon_type:
+            return self.get_data()["scientific_name"]
 
-    def get_taxonomic_lineage(self, ws_id):
-        #return self.ws_client.get_object_subset([{"ref": ws_id, "included": ["taxonomy"]}])[0]["data"]["taxonomy"]
-        pass
-    
-    def set_taxonomic_lineage(self, ws_id):
-        raise NotImplementedError
+    def get_taxonomic_id(self):
+        """
+        Retrieve the NCBI taxonomic id of this Taxon.
+        The KBaseGenomes.Genome type's closest representative is source_id.
+        
+        Unknown == -1
+        
+        Returns:
+          int"""
+        
+        if self._is_genome_type:
+            try:
+                return int(self.get_data_subset(["source_id"])["source_id"])
+            except:
+                return -1
+        elif self._is_taxon_type:
+            return self.get_data()["taxonomy_id"]
 
-    def get_scientific_name(self, ref_list=None):
-        raise NotImplementedError
+    def get_domain(self):
+        """
+        Retrieve the domain associated with this Taxonomic Unit.
+        
+        Returns:
+          str"""
+        
+        if self._is_genome_type:
+            return self.get_data_subset(["domain"])["domain"]
+        elif self._is_taxon_type:
+            return self.get_data()["domain"]
 
-    def get_taxonomic_id(self, ref_list=None):
-        raise NotImplementedError
+    def get_aliases(self):
+        """
+        Retrieve the aliases for this Taxonomic Unit.
+        
+        Returns:
+          list<str>"""        
+        
+        if self._is_genome_type:
+            return list()
+        elif self._is_taxon_type:
+            return self.get_data()["aliases"]
 
-    def get_domain(self, ref_list=None):
-        raise NotImplementedError
-
-    def get_aliases(self, ref_list=None):
-        raise NotImplementedError
-
-    def get_genetic_code(self, ref_list=None):
-        raise NotImplementedError
+    def get_genetic_code(self):
+        """
+        Retrieve the genetic code for this Taxonomic Unit.
+        
+        Returns:
+          int"""
+        
+        if self._is_genome_type:
+            return self.get_data_subset(["genetic_code"])["genetic_code"]
+        elif self._is_taxon_type:
+            return self.get_data()["genetic_code"]


### PR DESCRIPTION
Additional methods implemented for taxon and genome_annotation, doing the type checks at constructor time rather than per method, which made more sense.  The object constructor fills in metadata fields to make method calls simple lookups and not a fetch from ws each time.