### PR TITLE
improve code coverage for taxon_api

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[report]
+exclude_lines = 
+    pragma: no cover
+    pass
+
+[run]
+source = 
+    doekbase.data_api
+    doekbase.data_api.tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ script:
   - cd lib
   - touch .coverage
   - cd ..
-  - which nosetests
   - coverage run --source=doekbase.data_api /home/travis/virtualenv/python2.7.9/bin/nosetests --with-timer --ws-url=test_resources/data --wsfile-msgpack
   - coverage report
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ script:
   - cd lib
   - touch .coverage
   - cd ..
-  - coverage run --source=doekbase.data_api /usr/local/bin/nosetests --with-timer --ws-url=test_resources/data --wsfile-msgpack
+  - which nosetests
+  - coverage run --source=doekbase.data_api /home/travis/virtualenv/bin/nosetests --with-timer --ws-url=test_resources/data --wsfile-msgpack
   - coverage report
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ install:
   - python setup.py install
 
 script:
-  - cd lib
-  - touch .coverage
-  - cd ..
-  - coverage run --source=doekbase.data_api /home/travis/virtualenv/python2.7.9/bin/nosetests --with-timer --ws-url=test_resources/data --wsfile-msgpack
+#   cd lib
+#   touch .coverage
+#   cd ..
+  - coverage run /home/travis/virtualenv/python2.7.9/bin/nosetests --with-timer --ws-url=test_resources/data --wsfile-msgpack
   - coverage report
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - touch .coverage
   - cd ..
   - which nosetests
-  - coverage run --source=doekbase.data_api /home/travis/virtualenv/bin/nosetests --with-timer --ws-url=test_resources/data --wsfile-msgpack
+  - coverage run --source=doekbase.data_api /home/travis/virtualenv/python2.7.9/bin/nosetests --with-timer --ws-url=test_resources/data --wsfile-msgpack
   - coverage report
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ before_install:
   - git submodule update --init --recursive
 
 install:
-  - "mv requirements.txt requirements.txt-"
-  - "cp requirements-travis.txt requirements.txt"
-  - "python setup.py install"
- #"pip install -r requirements-travis.txt"
+  - mv requirements.txt requirements.txt-
+  - cp requirements-travis.txt requirements.txt
+  - python setup.py install
 
 script:
   - cd lib
   - touch .coverage
   - cd ..
-  - nosetests --with-coverage --ws-url=test_resources/data  --wsfile-msgpack
+  - coverage run --source=doekbase.data_api /usr/local/bin/nosetests --with-timer --ws-url=test_resources/data --wsfile-msgpack
+  - coverage report
 
 after_success:
   - codecov

--- a/lib/doekbase/data_api/sequence/assembly.py
+++ b/lib/doekbase/data_api/sequence/assembly.py
@@ -183,7 +183,7 @@ class AssemblyAPI(ObjectAPI, AssemblyInterface):
         return self.proxy.get_contig_lengths(contig_id_list)
 
     def get_contig_gc_content(self, contig_id_list=None):
-        return self.proxy.get_contig_lengths(contig_id_list)
+        return self.proxy.get_contig_gc_content(contig_id_list)
 
     def get_contig_ids(self):
         return self.proxy.get_contig_ids()

--- a/lib/doekbase/data_api/taxonomy/taxon/api.py
+++ b/lib/doekbase/data_api/taxonomy/taxon/api.py
@@ -130,6 +130,8 @@ class _KBaseGenomes_Genome(ObjectAPI, TaxonInterface):
     def __init__(self, services, token, ref):
         super(_KBaseGenomes_Genome, self).__init__(services, token, ref)
 
+        self.data = self.get_data_subset(["taxonomy", "scientific_name", "source_id", "domain", "genetic_code"])
+
     def get_parent(self, ref_only=False):
         return None
 
@@ -140,14 +142,14 @@ class _KBaseGenomes_Genome(ObjectAPI, TaxonInterface):
         return list()
 
     def get_scientific_lineage(self):
-        return self.get_data_subset(["taxonomy"])["taxonomy"]
+        return self.data["taxonomy"]
 
     def get_scientific_name(self):
-        return self.get_data_subset(["scientific_name"])["scientific_name"]
+        return self.data["scientific_name"]
 
     def get_taxonomic_id(self):
         try:
-            return int(self.get_data_subset(["source_id"])["source_id"])
+            return int(self.data["source_id"])
         except:
             return -1
 
@@ -155,13 +157,13 @@ class _KBaseGenomes_Genome(ObjectAPI, TaxonInterface):
         return None
 
     def get_domain(self):
-        return self.get_data_subset(["domain"])["domain"]
+        return self.data["domain"]
 
     def get_aliases(self):
         return list()
 
     def get_genetic_code(self):
-        return self.get_data_subset(["genetic_code"])["genetic_code"]
+        return self.data["genetic_code"]
 
 
 class _Prototype(ObjectAPI, TaxonInterface):

--- a/lib/doekbase/data_api/tests/test_taxon_api.py
+++ b/lib/doekbase/data_api/tests/test_taxon_api.py
@@ -41,8 +41,6 @@ def test_bogus_type():
             t = TaxonAPI(shared.services, shared.token, x)
         except Exception, e:
             assert isinstance(e, TypeError)
-        else:
-            assert False
 
 
 ####### New Taxon Type tests

--- a/lib/doekbase/data_api/tests/test_taxon_api.py
+++ b/lib/doekbase/data_api/tests/test_taxon_api.py
@@ -7,19 +7,26 @@ from unittest import skipUnless
 from . import shared
 
 from doekbase.data_api.taxonomy.taxon.api import TaxonAPI
+from doekbase.data_api.taxonomy.taxon.api import _Prototype
+from doekbase.data_api.taxonomy.taxon.api import _KBaseGenomes_Genome
+
 
 _log = logging.getLogger(__name__)
 
 taxon_new = "ReferenceTaxons/242159_taxon"
 taxon_old = "OriginalReferenceGenomes/kb|g.166819"
 t_new = None
+t_new_e = None
 t_old = None
+t_old_e = None
 
 def setup():
     shared.setup()
-    global t_new, t_old
+    global t_new, t_new_e, t_old, t_old_e
     t_new = TaxonAPI(shared.services, shared.token, taxon_new)
+    t_new_e = _Prototype(shared.services, shared.token, taxon_new)
     t_old = TaxonAPI(shared.services, shared.token, taxon_old)
+    t_old_e = _KBaseGenomes_Genome(shared.services, shared.token, taxon_old)
 
 ####### New Taxon Type tests
 
@@ -30,6 +37,9 @@ def test_get_parent_new():
     parent = t_new.get_parent()
     _log.info("Output {}".format(parent))
     assert isinstance(parent, TaxonAPI)
+    parent_e = t_new_e.get_parent()
+    assert isinstance(parent_e, TaxonAPI)
+    assert parent.get_taxonomic_id() == parent_e.get_taxonomic_id()
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -39,6 +49,9 @@ def test_get_children_new():
     _log.info("Output {}".format(children))
     assert isinstance(children, list)
     #and len(children) > 0
+    children_e = t_new_e.get_children()
+    assert isinstance(children, list)
+    assert children == children_e
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -48,6 +61,9 @@ def test_get_genome_annotations_new():
     _log.info("Output {}".format(annotations))
     assert isinstance(annotations, list)
     #and len(annotations) > 0
+    annotations_e = t_new_e.get_genome_annotations()
+    assert isinstance(annotations_e, list)
+    assert annotations == annotations_e
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -56,6 +72,9 @@ def test_get_scientific_lineage_new():
     scientific_lineage = t_new.get_scientific_lineage()
     _log.info("Output {}".format(scientific_lineage))
     assert isinstance(scientific_lineage, basestring) and len(scientific_lineage) > 0
+    scientific_lineage_e = t_new_e.get_scientific_lineage()
+    assert isinstance(scientific_lineage_e, basestring) and len(scientific_lineage_e) > 0
+    assert scientific_lineage == scientific_lineage_e
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -64,6 +83,9 @@ def test_get_scientific_name_new():
     scientific_name = t_new.get_scientific_name()
     _log.info("Output {}".format(scientific_name))
     assert isinstance(scientific_name, basestring) and len(scientific_name) > 0
+    scientific_name_e = t_new_e.get_scientific_name()
+    assert isinstance(scientific_name_e, basestring) and len(scientific_name_e) > 0
+    assert scientific_name == scientific_name_e
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -72,6 +94,9 @@ def test_get_taxonomic_id_new():
     taxonomic_id = t_new.get_taxonomic_id()
     _log.info("Output {}".format(taxonomic_id))
     assert isinstance(taxonomic_id, int) and taxonomic_id != -1
+    taxonomic_id_e = t_new_e.get_taxonomic_id()
+    assert isinstance(taxonomic_id_e, int) and taxonomic_id_e != -1
+    assert taxonomic_id == taxonomic_id_e
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -80,6 +105,8 @@ def test_get_kingdom_new():
     kingdom = t_new.get_kingdom()
     _log.info("Output {}".format(kingdom))
     assert kingdom == "Viridiplantae"
+    kingdom_e = t_new_e.get_kingdom()
+    assert kingdom_e == "Viridiplantae"
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -88,6 +115,9 @@ def test_get_domain_new():
     domain = t_new.get_domain()
     _log.info("Output {}".format(domain))
     assert isinstance(domain, basestring) and len(domain) > 0
+    domain_e = t_new_e.get_domain()
+    assert isinstance(domain_e, basestring) and len(domain_e) > 0
+    assert domain == domain_e
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -96,6 +126,9 @@ def test_get_aliases_new():
     aliases = t_new.get_aliases()
     _log.info("Output {}".format(aliases))
     assert isinstance(aliases, list) and len(aliases) > 0
+    aliases_e = t_new_e.get_aliases()
+    assert isinstance(aliases_e, list) and len(aliases_e) > 0
+    assert aliases == aliases_e
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -104,6 +137,9 @@ def test_get_genetic_code_new():
     genetic_code = t_new.get_genetic_code()
     _log.info("Output {}".format(genetic_code))
     assert isinstance(genetic_code, int) and genetic_code != -1
+    genetic_code_e = t_new_e.get_genetic_code()
+    assert isinstance(genetic_code_e, int) and genetic_code_e != -1
+    assert genetic_code == genetic_code_e
 
 
 ####### Old Taxon Type tests
@@ -115,6 +151,8 @@ def test_get_parent_old():
     parent = t_old.get_parent()
     _log.info("Output {}".format(parent))
     assert parent is None
+    parent_e = t_old_e.get_parent()
+    assert parent_e is None
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -123,6 +161,9 @@ def test_get_children_old():
     children = t_old.get_children()
     _log.info("Output {}".format(children))
     assert isinstance(children, list) and len(children) == 0
+    children_e = t_old_e.get_children()
+    assert isinstance(children_e, list) and len(children_e) == 0
+    assert children == children_e
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -131,6 +172,9 @@ def test_get_genome_annotations_old():
     annotations = t_old.get_genome_annotations()
     _log.info("Output {}".format(annotations))
     assert isinstance(annotations, list) and len(annotations) == 0
+    annotations_e = t_old_e.get_genome_annotations()
+    assert isinstance(annotations_e, list) and len(annotations_e) == 0
+    assert annotations == annotations_e
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -139,6 +183,9 @@ def test_get_scientific_lineage_old():
     scientific_lineage = t_old.get_scientific_lineage()
     _log.info("Output {}".format(scientific_lineage))
     assert isinstance(scientific_lineage, basestring) and len(scientific_lineage) > 0
+    scientific_lineage_e = t_old_e.get_scientific_lineage()
+    assert isinstance(scientific_lineage_e, basestring) and len(scientific_lineage_e) > 0
+    assert scientific_lineage == scientific_lineage_e
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -147,6 +194,9 @@ def test_get_scientific_name_old():
     scientific_name = t_old.get_scientific_name()
     _log.info("Output {}".format(scientific_name))
     assert isinstance(scientific_name, basestring) and len(scientific_name) > 0
+    scientific_name_e = t_old_e.get_scientific_name()
+    assert isinstance(scientific_name_e, basestring) and len(scientific_name_e) > 0
+    assert scientific_name == scientific_name_e
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -155,15 +205,19 @@ def test_get_taxonomic_id_old():
     taxonomic_id = t_old.get_taxonomic_id()
     _log.info("Output {}".format(taxonomic_id))
     assert isinstance(taxonomic_id, int) and taxonomic_id == -1
+    taxonomic_id_e = t_old_e.get_taxonomic_id()
+    assert isinstance(taxonomic_id_e, int) and taxonomic_id_e == -1
+    assert taxonomic_id == taxonomic_id_e
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
 def test_get_kingdom_old():
     _log.info("Input {}".format(taxon_old))
     kingdom = t_old.get_kingdom()
-    print kingdom
     _log.info("Output {}".format(kingdom))
     assert kingdom is None
+    kingdom_e = t_old_e.get_kingdom()
+    assert kingdom_e is None
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -172,6 +226,9 @@ def test_get_domain_old():
     domain = t_old.get_domain()
     _log.info("Output {}".format(domain))
     assert isinstance(domain, basestring) and len(domain) > 0
+    domain_e = t_old_e.get_domain()
+    assert isinstance(domain_e, basestring) and len(domain_e) > 0
+    assert domain == domain_e
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -180,6 +237,9 @@ def test_get_aliases_old():
     aliases = t_old.get_aliases()
     _log.info("Output {}".format(aliases))
     assert isinstance(aliases, list) and len(aliases) == 0
+    aliases_e = t_old_e.get_aliases()
+    assert isinstance(aliases_e, list) and len(aliases_e) == 0
+    assert aliases == aliases_e
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
@@ -188,3 +248,5 @@ def test_get_genetic_code_old():
     genetic_code = t_old.get_genetic_code()
     _log.info("Output {}".format(genetic_code))
     assert isinstance(genetic_code, int) and genetic_code != -1
+    genetic_code_e = t_old_e.get_genetic_code()
+    assert isinstance(genetic_code_e, int) and genetic_code_e != -1

--- a/lib/doekbase/data_api/tests/test_taxon_api.py
+++ b/lib/doekbase/data_api/tests/test_taxon_api.py
@@ -28,6 +28,23 @@ def setup():
     t_old = TaxonAPI(shared.services, shared.token, taxon_old)
     t_old_e = _KBaseGenomes_Genome(shared.services, shared.token, taxon_old)
 
+
+@skipUnless(shared.can_connect, 'Cannot connect to workspace')
+def test_bogus_type():
+    inputs = ["Bogus",
+              "PrototypeReferenceGenomes/kb|g.166819",
+              "PrototypeReferenceGenomes/kb|g.166819_assembly",
+              "OriginalReferenceGenomes/kb|g.166819.contigset"]
+    _log.info("Input {}".format(inputs))
+    for x in inputs:
+        try:
+            t = TaxonAPI(shared.services, shared.token, x)
+        except Exception, e:
+            assert isinstance(e, TypeError)
+        else:
+            assert False
+
+
 ####### New Taxon Type tests
 
 

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -4,6 +4,8 @@ Jinja2==2.7.3
 mongomock==3.0.0
 msgpack-python==0.4.6
 nose
+nose-timer
+coverage
 requests==2.7.0
 six==1.9.0
 Sphinx<=1.2.99

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,9 @@ Jinja2==2.7.3
 Sphinx<=1.2.99
 sphinxcontrib-napoleon>=0.3.0
 nose
-python-coveralls
+nose-timer
+coverage
+codecov
 six==1.9.0
 enum34
 pandas==0.16.2

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ config = {
     "author_email": "mhenderson@lbl.gov",
     "version": version,
     "setup_requires": ["six"],
-    "tests_require": ["nose"],
+    "tests_require": ["nose", "nose-timer", "codecov"],
     "install_requires": parse_requirements(),
     "packages": ["doekbase",
                  "doekbase.data_api",


### PR DESCRIPTION
instantiate each internal subclass as part of taxon tests and verify that tests pass and match results going through proxy object
caught a bug in assembly where the proxy object was calling the wrong method for get_contig_gc_content
added nose-timer and --with-timer to nosetests, shows timing per test in the travis build, can be used locally to evaluate performance effects
running nosetests in travis using coverage script to get coverage of imports, classes, method definitions, etc since --with-coverage did not seem able to do this
added .coveragerc with run and report options, exclude abstract method bodies with pass statement from coverage
added one test for taxon api constructor