### PR TITLE
Added codecov graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository is configured to use TravisCI
 Source code is under lib/ (Python)
 [![Build Status](https://travis-ci.org/kbase/data_api.svg?branch=master)](https://travis-ci.org/kbase/data_api)
 [![Coverage Status](http://codecov.io/github/kbase/data_api/coverage.svg?branch=master)](http://codecov.io/github/kbase/data_api?branch=master)
+![Coverage Graph](http://codecov.io/github/kbase/data_api/branch.svg?branch=master&time=1y)
 
 #quickstart instructions
 


### PR DESCRIPTION
This addition will display a graph of code coverage for the last 20 commits within a 1 year timeframe.