### PR TITLE
For Issue #KBASE-2751: Fix Performance Overhead of Workspace File

### DIFF
--- a/lib/doekbase/data_api/core.py
+++ b/lib/doekbase/data_api/core.py
@@ -5,7 +5,7 @@ Module for base class for Data API objects.
 # Imports
 
 # Stdlib
-import glob
+import logging
 import os
 import re
 try:
@@ -72,7 +72,7 @@ class ObjectAPI(object):
 
         ws_url = services["workspace_service_url"]
         if '://' in ws_url: # assume a real Workspace server
-            if token == None or len(token.strip()) == 0:
+            if token is None or len(token.strip()) == 0:
                 self._token = get_token()
             else:
                 self._token = token
@@ -108,7 +108,8 @@ class ObjectAPI(object):
         }
         self._id = self._info["object_id"]
         self._name = self._info["object_name"]
-        self._typestring = self.ws_client.translate_to_MD5_types([self._info["type_string"]]).values()[0]
+        self._typestring = self.ws_client.translate_to_MD5_types(
+            [self._info["type_string"]]).values()[0]
         self._version = self._info["version"]
         self._schema = None
         self._history = None
@@ -116,23 +117,23 @@ class ObjectAPI(object):
         self._data = None
 
     def _init_ws_from_files(self, path):
-        #if g_use_msgpack:
-        ext = 'msgpack'
+        ext = '.msgpack'
+        extlen = len(ext)
         WorkspaceFile.use_msgpack = True
-        #else:
-        #    ext = 'json'
-        #    WorkspaceFile.use_msgpack = False
-        input_files = glob.glob(os.path.join(path, '*.' + ext))
-        if len(input_files) == 0:
-            raise ValueError('No .{} files found for file-based Workspace '
-                             'in path "{}"'.format(ext, path))
-        client = WorkspaceFile()
-        for f in input_files:
-            #t0 = log_start(_log, 'client.load', level=logging.DEBUG,
-            #               kvp={'file': f})
-            client.load(f)
-            #log_end(_log, t0, 'client.load', level=logging.DEBUG,
-            #        kvp={'file': f})
+        client = WorkspaceFile(path)
+        num_loaded = 0
+        for name in os.listdir(path):
+            if name.endswith(ext):
+                ref = name[:-extlen]
+                t0 = log_start(_log, 'load', level=logging.DEBUG,
+                               kvp={'ref': ref})
+                client.load(ref)
+                log_end(_log, t0, 'client.load', level=logging.DEBUG,
+                        kvp={'ref': ref})
+            num_loaded += 1
+        if num_loaded == 0:
+            raise ValueError('No files with extension "{e}" found in path {p}'
+                             .format(e=ext, p=path))
         return client
 
     def get_schema(self):
@@ -142,7 +143,7 @@ class ObjectAPI(object):
         Returns:
           string"""
     
-        if self._schema == None:
+        if self._schema is None:
             self._schema = self.ws_client.get_type_info(self.get_info()["type_string"])
         
         return self._schema

--- a/lib/doekbase/data_api/tests/nose_plugin_wsurl.py
+++ b/lib/doekbase/data_api/tests/nose_plugin_wsurl.py
@@ -12,7 +12,7 @@ from doekbase.data_api import core
 from doekbase.data_api.util import get_logger
 
 # Logging
-_log = get_logger('nose_plugin_wsurl')
+_log = get_logger(__name__)
 
 class WorkspaceURL(Plugin):
     """Plugin that sets up the Workspace mocking instead of the
@@ -21,6 +21,7 @@ class WorkspaceURL(Plugin):
     def options(self, parser, env):
         """Register commmandline options.
         """
+        _log.info('WorkspaceURL.options')
         # Shock URL
         parser.add_option(
             "--shock-url", dest="shock_url", metavar='URL',
@@ -46,6 +47,7 @@ class WorkspaceURL(Plugin):
     def configure(self, options, conf):
         """Configure plugin.
         """
+        _log.info('WorkspaceURL.configure, ws_url={}'.format(options.ws_url))
         if not self.can_configure:
             return
         # Assign parsed values to global variables in the 'core' module.

--- a/lib/doekbase/data_api/tests/shared.py
+++ b/lib/doekbase/data_api/tests/shared.py
@@ -25,8 +25,10 @@ services = None
 
 # Functions and classes
 def get_services():
-    return {"workspace_service_url": g_ws_url,
+    svc = {"workspace_service_url": g_ws_url,
             "shock_service_url": g_shock_url}
+    print("@@ service URLs = {}".format(svc))
+    return svc
 
 def can_connect(ref=genome):
     """See if we can get a connection to the workspace and access the

--- a/lib/doekbase/data_api/tests/shared.py
+++ b/lib/doekbase/data_api/tests/shared.py
@@ -27,7 +27,7 @@ services = None
 def get_services():
     svc = {"workspace_service_url": g_ws_url,
             "shock_service_url": g_shock_url}
-    print("@@ service URLs = {}".format(svc))
+    #print("@@ service URLs = {}".format(svc))
     return svc
 
 def can_connect(ref=genome):

--- a/lib/doekbase/data_api/util.py
+++ b/lib/doekbase/data_api/util.py
@@ -24,13 +24,13 @@ DEFAULT_LEVEL_NAME = logging.getLevelName(DEFAULT_LEVEL)
 DEFAULT_CONFIG = {
     'version': 1,
     'formatters': {
-        'basic': { 'format': '[%(levelname)s] (%(name)s) %(funcName)s() %(message)s' }
+        'basic': { 'format': '%(levelname)s %(message)s' }
     },
     'handlers': {
         'console': {
             'class': 'logging.StreamHandler',
             'formatter': 'basic',
-            'stream': 'ext://sys.stdout',
+            'stream': 'ext://sys.stderr',
             'level': DEFAULT_LEVEL_NAME
         }
     },


### PR DESCRIPTION
Streamlined loading of workspace files, handling caching directly in the WorkspaceFile class, and made sure that lookup-by-reference does not copy the data. Most changes were to the `load` method in the `WorkspaceFile` class in the `doekbase.data_api.wsfile` module, but some changes also needed to be made in `_init_ws_from_files` method in the `ObjectAPI` class of the `doekbase.data_api.core` module. Since the signature of the WorkspaceFile constructor and `load` method both changed, tests also had to be updated.