### PR TITLE
first pass at deployment, service start/stop scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ deploy-client: deploy
 deploy:
 	rm -rf $(SERVICE_DIR)/venv
 	virtualenv $(SERVICE_DIR)/venv
-	. $(SERVICE_DIR)/venv/bin/activate && pip install -vvv .
 	cp $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME) $(SERVICE_DIR)/
 	rsync -avzP $(LBIN_DIR) $(SERVICE_DIR)/
+	. $(SERVICE_DIR)/venv/bin/activate && pip install -vvv .
 
 clean:
 	echo not implemented

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+SERVICE = dataapi
+SERVICE_CAPS = dataApi
+LIB_DIR = lib
+SCRIPTS_DIR = scripts
+LBIN_DIR = bin
+TARGET ?= /kb/deployment
+SERVICE_DIR ?= $(TARGET)/services/$(SERVICE)
+EXECUTABLE_SCRIPT_NAME = run_$(SERVICE_CAPS)_async_job.sh
+STARTUP_SCRIPT_NAME = start_server.sh
+KB_RUNTIME ?= /kb/runtime
+ANT = $(KB_RUNTIME)/ant/bin/ant
+
+default: deploy
+
+deploy:
+	rm -rf $(SERVICE_DIR)/venv
+	virtualenv $(SERVICE_DIR)/venv
+	. $(SERVICE_DIR)/venv/bin/activate && pip install -vvv .
+	cp $(SCRIPTS_DIR)/start_service.sh $(SERVICE_DIR)/
+	rsync $(LBIN_DIR) $(SERVICE_DIR)/
+
+clean:
+	echo not implemented

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,7 @@ deploy:
 	virtualenv $(SERVICE_DIR)/venv
 	. $(SERVICE_DIR)/venv/bin/activate && pip install -vvv .
 	cp $(SCRIPTS_DIR)/start_service.sh $(SERVICE_DIR)/
-	rsync $(LBIN_DIR) $(SERVICE_DIR)/
-
+	rsync -avzP $(LBIN_DIR) $(SERVICE_DIR)/
 
 clean:
 	echo not implemented

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,15 @@ ANT = $(KB_RUNTIME)/ant/bin/ant
 
 default: deploy
 
-deploy-client: deploy
+# not really sure what to do with this target yet
+deploy-client: 
 
 deploy:
 	rm -rf $(SERVICE_DIR)/venv
 	virtualenv $(SERVICE_DIR)/venv
 	cp $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME) $(SERVICE_DIR)/
 	rsync -avzP $(LBIN_DIR) $(SERVICE_DIR)/
-	. $(SERVICE_DIR)/venv/bin/activate && pip install -vvv .
+	. $(SERVICE_DIR)/venv/bin/activate && pip install .
 
 clean:
 	echo not implemented

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ deploy-client:
 deploy:
 	rm -rf $(SERVICE_DIR)/venv
 	virtualenv $(SERVICE_DIR)/venv
-	cp $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME) $(SERVICE_DIR)/
+	cp $(SCRIPTS_DIR)/start_service $(SCRIPTS_DIR)/stop_service (SERVICE_DIR)/
 	rsync -avzP $(LBIN_DIR) $(SERVICE_DIR)/
 	. $(SERVICE_DIR)/venv/bin/activate && pip install .
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LBIN_DIR = bin
 TARGET ?= /kb/deployment
 SERVICE_DIR ?= $(TARGET)/services/$(SERVICE)
 EXECUTABLE_SCRIPT_NAME = run_$(SERVICE_CAPS)_async_job.sh
-STARTUP_SCRIPT_NAME = start_server
+STARTUP_SCRIPT_NAME = start_service
 KB_RUNTIME ?= /kb/runtime
 ANT = $(KB_RUNTIME)/ant/bin/ant
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LBIN_DIR = bin
 TARGET ?= /kb/deployment
 SERVICE_DIR ?= $(TARGET)/services/$(SERVICE)
 EXECUTABLE_SCRIPT_NAME = run_$(SERVICE_CAPS)_async_job.sh
-STARTUP_SCRIPT_NAME = start_server.sh
+STARTUP_SCRIPT_NAME = start_server
 KB_RUNTIME ?= /kb/runtime
 ANT = $(KB_RUNTIME)/ant/bin/ant
 
@@ -18,7 +18,7 @@ deploy:
 	rm -rf $(SERVICE_DIR)/venv
 	virtualenv $(SERVICE_DIR)/venv
 	. $(SERVICE_DIR)/venv/bin/activate && pip install -vvv .
-	cp $(SCRIPTS_DIR)/start_service.sh $(SERVICE_DIR)/
+	cp $(SCRIPTS_DIR)/$(STARTUP_SCRIPT_NAME) $(SERVICE_DIR)/
 	rsync -avzP $(LBIN_DIR) $(SERVICE_DIR)/
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ deploy-client:
 deploy:
 	rm -rf $(SERVICE_DIR)/venv
 	virtualenv $(SERVICE_DIR)/venv
-	cp $(SCRIPTS_DIR)/start_service $(SCRIPTS_DIR)/stop_service (SERVICE_DIR)/
+	cp $(SCRIPTS_DIR)/start_service $(SCRIPTS_DIR)/stop_service $(SERVICE_DIR)/
 	rsync -avzP $(LBIN_DIR) $(SERVICE_DIR)/
 	. $(SERVICE_DIR)/venv/bin/activate && pip install .
 

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,15 @@ ANT = $(KB_RUNTIME)/ant/bin/ant
 
 default: deploy
 
+deploy-client: deploy
+
 deploy:
 	rm -rf $(SERVICE_DIR)/venv
 	virtualenv $(SERVICE_DIR)/venv
 	. $(SERVICE_DIR)/venv/bin/activate && pip install -vvv .
 	cp $(SCRIPTS_DIR)/start_service.sh $(SERVICE_DIR)/
 	rsync $(LBIN_DIR) $(SERVICE_DIR)/
+
 
 clean:
 	echo not implemented

--- a/scripts/start_service
+++ b/scripts/start_service
@@ -1,6 +1,7 @@
 #!/bin/bash
 script_dir=$(dirname "$(readlink -f "$0")")
 export KB_DEPLOYMENT_CONFIG=$script_dir/deploy.cfg
+source $script_dir/venv/bin/activate
 
 for api in taxon
 do

--- a/scripts/start_service
+++ b/scripts/start_service
@@ -5,6 +5,6 @@ export KB_DEPLOYMENT_CONFIG=$script_dir/deploy.cfg
 for api in taxon
 do
 # this doesn't yet capture stdout/stderr
-    echo starting service for $api
-    python $script_dir/bin/${api}_start_service.py &
+    echo starting service for $api (in foreground)
+    python $script_dir/bin/${api}_start_service.py
 done

--- a/scripts/start_service
+++ b/scripts/start_service
@@ -5,7 +5,5 @@ source $script_dir/venv/bin/activate
 
 for api in taxon
 do
-# this doesn't yet capture stdout/stderr
-    echo starting service for $api
     daemonize -c $script_dir -o $script_dir/stdout -e $script_dir/stderr -a -v $script_dir/venv/bin/python $script_dir/bin/${api}_start_service.py
 done

--- a/scripts/start_service
+++ b/scripts/start_service
@@ -7,5 +7,5 @@ for api in taxon
 do
 # this doesn't yet capture stdout/stderr
     echo starting service for $api in foreground
-    python $script_dir/bin/${api}_start_service.py
+    python $script_dir/bin/${api}_start_service.py &
 done

--- a/scripts/start_service
+++ b/scripts/start_service
@@ -1,0 +1,9 @@
+#!/bin/bash
+script_dir=$(dirname "$(readlink -f "$0")")
+export KB_DEPLOYMENT_CONFIG=$script_dir/deploy.cfg
+
+for api in taxon
+do
+# this doesn't yet capture stdout/stderr
+    python $script_dir/bin/${api}_start_service.py &
+done

--- a/scripts/start_service
+++ b/scripts/start_service
@@ -5,6 +5,6 @@ export KB_DEPLOYMENT_CONFIG=$script_dir/deploy.cfg
 for api in taxon
 do
 # this doesn't yet capture stdout/stderr
-    echo starting service for $api (in foreground)
+    echo starting service for $api in foreground
     python $script_dir/bin/${api}_start_service.py
 done

--- a/scripts/start_service
+++ b/scripts/start_service
@@ -7,5 +7,5 @@ for api in taxon
 do
 # this doesn't yet capture stdout/stderr
     echo starting service for $api in foreground
-    python $script_dir/bin/${api}_start_service.py &
+    daemonize -o $script_dir/stdout -e $script_dir/stderr -a python $script_dir/bin/${api}_start_service.py
 done

--- a/scripts/start_service
+++ b/scripts/start_service
@@ -6,6 +6,6 @@ source $script_dir/venv/bin/activate
 for api in taxon
 do
 # this doesn't yet capture stdout/stderr
-    echo starting service for $api in foreground
-    daemonize -o $script_dir/stdout -e $script_dir/stderr -a python $script_dir/bin/${api}_start_service.py
+    echo starting service for $api
+    daemonize -c $script_dir -o $script_dir/stdout -e $script_dir/stderr -a -v $script_dir/venv/bin/python $script_dir/bin/${api}_start_service.py
 done

--- a/scripts/start_service
+++ b/scripts/start_service
@@ -5,5 +5,6 @@ export KB_DEPLOYMENT_CONFIG=$script_dir/deploy.cfg
 for api in taxon
 do
 # this doesn't yet capture stdout/stderr
+    echo starting service for $api
     python $script_dir/bin/${api}_start_service.py &
 done

--- a/scripts/start_service.sh
+++ b/scripts/start_service.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 script_dir=$(dirname "$(readlink -f "$0")")
-export KB_DEPLOYMENT_CONFIG=$script_dir/../deploy.cfg
+export KB_DEPLOYMENT_CONFIG=$script_dir/deploy.cfg
 
 for api in taxon
 do
-    python $script_dir/../bin/${api}_start_service.py
+# this doesn't yet capture stdout/stderr
+    python $script_dir/bin/${api}_start_service.py &
 done

--- a/scripts/start_service.sh
+++ b/scripts/start_service.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-script_dir=$(dirname "$(readlink -f "$0")")
-export KB_DEPLOYMENT_CONFIG=$script_dir/deploy.cfg
-
-for api in taxon
-do
-# this doesn't yet capture stdout/stderr
-    python $script_dir/bin/${api}_start_service.py &
-done

--- a/scripts/start_service.sh
+++ b/scripts/start_service.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+script_dir=$(dirname "$(readlink -f "$0")")
+export KB_DEPLOYMENT_CONFIG=$script_dir/../deploy.cfg
+
+for api in taxon
+do
+    python $script_dir/../bin/${api}_start_service.py
+done

--- a/scripts/stop_service
+++ b/scripts/stop_service
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kill $(cat /kb/deployment/services/dataapi/TaxonAPI.pid)

--- a/scripts/stop_service
+++ b/scripts/stop_service
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-kill $(cat /kb/deployment/services/dataapi/TaxonAPI.pid)
+script_dir=$(dirname "$(readlink -f "$0")")
+export KB_DEPLOYMENT_CONFIG=$script_dir/deploy.cfg
+source $script_dir/venv/bin/activate
+
+kill $(cat $script_dir/TaxonAPI.pid)
+


### PR DESCRIPTION
This PR adds a Makefile which does a fairly crude deploy, and contains start and stop scripts for running the API services.  It's a first pass, so the scripts are crude, some things are still hardcoded, and the service script still doesn't read in the deploy.cfg file on startup and still has hardcoded configs for starting the taxon API service.  However, it does deploy in -ci successfully and starts up a listener.  I'll work on improving the shell scripts and moving the Python script to use deploy.cfg.