### PR TITLE
[WIP] service should listen on all interfaces

### DIFF
--- a/bin/taxon_start_service.py
+++ b/bin/taxon_start_service.py
@@ -49,7 +49,7 @@ def main():
         #signal.signal(signal.SIGHUP, driver.reload_config())
 
         try:
-            driver.start_service(port=args.port)
+            driver.start_service(port=args.port,host='')
         finally:
             pidfile.release()
     except lockfile.LockFailed:


### PR DESCRIPTION
The API service should listen on all interfaces by default.  This hasn't been well tested, please don't merge yet.