### PR TITLE
fixed bug with generated oid

### DIFF
--- a/lib/doekbase/data_api/wsfile.py
+++ b/lib/doekbase/data_api/wsfile.py
@@ -304,14 +304,15 @@ class WorkspaceFile(object):
     def ver(self):
         return self.VERSION
 
+    def get_children(self):
+        return []
+
     # ___ Internal methods ___
 
     def _get_oid(self, ref):
         if ref in self._oids:
             return self._oids[ref]
-        n = len(self._oids)
-        pfx = abs(hash(ref))
-        new_oid = int('{:d}{:04d}'.format(pfx, n + 1))
+        new_oid = len(self._oids)
         self._oids[ref] = new_oid
         return new_oid
 
@@ -349,11 +350,12 @@ class WorkspaceFile(object):
 		8: string chsum, 9: int size, 10: usermeta meta
         """
         assert re.match(NUMERIC_REF_PAT, ref)  # require numeric ref
-        ver = '1'
+        wsid = int(ref.split('/')[0])
+        ver = int(ref.split('/')[-1])
         return (self._get_oid(ref), record['name'],
                 record['type'], datetime.isoformat(datetime.now()),
-                record['type'] + '/' + ver, None,
-                ver, None,
+                ver, 'joe',
+                wsid, record['name'],
                 '0', 0, {}
                 )
     def _make_object(self, record, ref, data=None):

--- a/lib/doekbase/data_api/wsfile.py
+++ b/lib/doekbase/data_api/wsfile.py
@@ -17,6 +17,7 @@ import logging
 import msgpack
 import os
 import re
+import sys
 # Third-party
 import mongomock as mm
 # Local
@@ -312,7 +313,7 @@ class WorkspaceFile(object):
     def _get_oid(self, ref):
         if ref in self._oids:
             return self._oids[ref]
-        new_oid = len(self._oids)
+        new_oid = (len(self._oids) + abs(hash(ref))) % sys.maxint
         self._oids[ref] = new_oid
         return new_oid
 


### PR DESCRIPTION
Also fixed a bug with the info-tuple being returned (reference name was being returned in the slot for the version). There is another problem farther down the line with get_children(), but that may be something else. Merging this commit will get rid of the Thrift complaints about bad int64 values.

Only one file should be modified, wsfile.py