### PR TITLE
GenomeAnnotationAPI bug fixes

### DIFF
--- a/bin/genome_annotation_client_driver.py
+++ b/bin/genome_annotation_client_driver.py
@@ -55,9 +55,38 @@ def test_client():
     print("Got and parsed data from get_feature_type_counts() in {:g} seconds".format(dt))
 
     t0 = time.time()
-    feature_ids = api.get_feature_ids()
+    feature_ids = api.get_feature_ids(filters={"type_list": ["CDS"]})
     dt = time.time() - t0
-    print feature_ids
+    print feature_ids["by_type"]["CDS"][0:2]
+    print("Got and parsed data from get_feature_ids() in {:g} seconds".format(dt))
+
+    locations = api.get_feature_locations(feature_ids["by_type"]["CDS"][0:2])
+    regions = list()
+    for x in locations:
+        regions.extend(locations[x])
+
+    t0 = time.time()
+    feature_ids = api.get_feature_ids(filters={"region_list": regions}, group_by="region")
+    dt = time.time() - t0
+    print feature_ids["by_region"].items()[0]
+    print("Got and parsed data from get_feature_ids() in {:g} seconds".format(dt))
+
+    t0 = time.time()
+    feature_ids = api.get_feature_ids(filters={"function_list": ["protein"]}, group_by="function")
+    dt = time.time() - t0
+    print feature_ids["by_function"].items()[0]
+    print("Got and parsed data from get_feature_ids() in {:g} seconds".format(dt))
+
+    t0 = time.time()
+    feature_ids = api.get_feature_ids(filters={"alias_list": ["29216","93082"]}, group_by="alias")
+    dt = time.time() - t0
+    print feature_ids["by_alias"]
+    print("Got and parsed data from get_feature_ids() in {:g} seconds".format(dt))
+
+    t0 = time.time()
+    feature_ids = api.get_feature_ids(group_by="type")
+    dt = time.time() - t0
+    print feature_ids.keys()
     print("Got and parsed data from get_feature_ids() in {:g} seconds".format(dt))
 
     t0 = time.time()
@@ -69,7 +98,7 @@ def test_client():
     t0 = time.time()
     proteins = api.get_proteins()
     dt = time.time() - t0
-    print proteins
+    print proteins.items()[0]
     print("Got and parsed data from get_proteins() in {:g} seconds".format(dt))
 
     t0 = time.time()

--- a/lib/doekbase/data_api/cache.py
+++ b/lib/doekbase/data_api/cache.py
@@ -130,7 +130,7 @@ class ObjectCache(object):
         cp = cache_params or self.cache_params
         self._cache = cc(**cp)  # workers of the world unite!
         self._stats.end_event('cache.init', self._key)
-        _log.info('ObjectCache.init.end cache_class={}'.format(
+        _log.debug('ObjectCache.init.end cache_class={}'.format(
             cc.__name__))
 
     def get_derived_data(self, parent_method, name):

--- a/lib/doekbase/data_api/wsfile.py
+++ b/lib/doekbase/data_api/wsfile.py
@@ -160,12 +160,12 @@ class WorkspaceFile(object):
           ValueError: parsing failed.
         """
         # log start
-        t0 = log_start(_log, 'WorkspaceFile.load', level=logging.INFO,
+        t0 = log_start(_log, 'WorkspaceFile.load', level=logging.DEBUG,
                        kvp=dict(ref=ref))
         # stop if already loaded in the past
         if ref in self._loaded:
             # log done and return
-            log_end(_log, t0, 'WorkspaceFile.load', level=logging.INFO,
+            log_end(_log, t0, 'WorkspaceFile.load', level=logging.DEBUG,
                     kvp=dict(ref=ref, cached='yes'))
             return
         # create the full path from the reference
@@ -191,7 +191,7 @@ class WorkspaceFile(object):
         # insert the parsed data into mongomock
         self.collection.insert(record)
         # log done
-        log_end(_log, t0, 'WorkspaceFile.load', level=logging.INFO,
+        log_end(_log, t0, 'WorkspaceFile.load', level=logging.DEBUG,
                 kvp=dict(ref=ref, cached='no'))
 
     def unload(self, ref):


### PR DESCRIPTION
Fixed a number of issues with GA methods found, including get_feature_ids() with different parameter permutations, inconsistent handling of genome region specifiers, etc.

Some minor changes to wsfile.py and cache.py to set detailed logging info to debug.

Currently this command reveals at least one issue that is not addressed in this PR:
python bin/genome_annotation_client_driver.py --ref "OriginalReferenceGenomes/kb|g.166819"

Traceback (most recent call last):
  File "bin/genome_annotation_client_driver.py", line 171, in <module>
    test_client() # XXX: choose one with top-level args
  File "bin/genome_annotation_client_driver.py", line 77, in test_client
    print feature_ids["by_function"].items()[0]
IndexError: list index out of range

Some debugging info:

len(features) == 1 ?
function: PF00581 ; KOG1530 , filter: protein

This yields no results due to the filter not appearing in the single feature.  However there are more than 7,000 CDS, mRNA, gene features each, many of which contain "protein" in the function description.  This works fine for the new data type on disk, so I suspect something buggy in fetching the data from the old type on disk in either wsfile or cache.