### PR TITLE
disable feature level publication info for now

### DIFF
--- a/lib/doekbase/data_api/annotation/genome_annotation/api.py
+++ b/lib/doekbase/data_api/annotation/genome_annotation/api.py
@@ -1362,10 +1362,11 @@ class _GenomeAnnotation(ObjectAPI, GenomeAnnotationInterface):
             else:
                 f["feature_function"] = ""
 
-            if 'publications' in x:
-                f["feature_publications"] = x['publications']
-            else:
-                f["feature_publications"] = []
+            #if 'publications' in x:
+            #    f["feature_publications"] = x['publications']
+            #else:
+            # TODO fix publications in thrift spec and code, problem with existing data
+            f["feature_publications"] = []
 
             if 'aliases' in x:
                 f["feature_aliases"] = x['aliases']


### PR DESCRIPTION
We need to figure out how this should really work.  At the moment this is not working anyway because of the thrift spec.