### PR TITLE
disable feature publications for now

### DIFF
--- a/lib/doekbase/data_api/annotation/genome_annotation/api.py
+++ b/lib/doekbase/data_api/annotation/genome_annotation/api.py
@@ -1362,10 +1362,11 @@ class _GenomeAnnotation(ObjectAPI, GenomeAnnotationInterface):
             else:
                 f["feature_function"] = ""
 
-            if 'publications' in x:
-                f["feature_publications"] = x['publications']
-            else:
-                f["feature_publications"] = []
+            #if 'publications' in x:
+            #    f["feature_publications"] = x['publications']
+            #else:
+            # TODO fix publications in thrift spec and code, problem with existing data
+            f["feature_publications"] = []
 
             if 'aliases' in x:
                 f["feature_aliases"] = x['aliases']


### PR DESCRIPTION
Disabling feature publications in the API for now until we can determine what we're doing with these.  At the moment the thrift spec is not matched up to the type spec publications, so it isn't working anyway.