### PR TITLE
removed '?' as acceptable strand string for queries

### DIFF
--- a/lib/doekbase/data_api/annotation/genome_annotation/api.py
+++ b/lib/doekbase/data_api/annotation/genome_annotation/api.py
@@ -141,14 +141,11 @@ class GenomeAnnotationInterface(object):
               `FEATURE_DESCRIPTIONS`.
 
             - `region_list`: List of region specs. e.g.,
-              ``[{"contig_id": str, "strand": "+"|"-"|"?", "start": int, "length": int},...]``
+              ``[{"contig_id": str, "strand": "+"|"-", "start": int, "length": int},...]``
 
                 The Feature sequence begin and end are calculated as follows:
                   [start, start + length) for "+" strand
                   (start - length, start] for "-" strand
-
-                  If passing in "?" for strand, meaning either, the above
-                  calculations will apply to the correct strand type of the data.
 
             - `function_list`: List of function strings to match.
 
@@ -607,9 +604,7 @@ class _KBaseGenomes_Genome(ObjectAPI, GenomeAnnotationInterface):
 
                 for loc in f["location"]:
                     for r in regions:
-                        if r["contig_id"] == loc[0] and \
-                           (loc[2] == r["strand"] or r["strand"] == "?"):
-
+                        if r["contig_id"] == loc[0] and loc[2] == r["strand"]:
                             if loc[2] == "+" and \
                                max(loc[1], r["start"]) <= min(loc[1]+loc[3], r["start"] + r["length"]):
                                 return True
@@ -1149,9 +1144,7 @@ class _GenomeAnnotation(ObjectAPI, GenomeAnnotationInterface):
             def is_feature_in_regions(f, regions):
                 for loc in f["locations"]:
                     for r in regions:
-                        if r["contig_id"] == loc[0] and \
-                           (loc[2] == r["strand"] or r["strand"] == "?"):
-
+                        if r["contig_id"] == loc[0] and loc[2] == r["strand"]:
                             if loc[2] == "+" and \
                                max(loc[1], r["start"]) <= min(loc[1] + loc[3], r["start"] + r["length"]):
                                 return True

--- a/lib/doekbase/data_api/tests/test_genome_annotation_api.py
+++ b/lib/doekbase/data_api/tests/test_genome_annotation_api.py
@@ -158,24 +158,6 @@ def test_get_feature_ids_new_filter_plus_strand_by_region():
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
-def test_get_feature_ids_new_filter_either_strand_by_region():
-    _log.debug("Input {}".format(genome_new))
-    for t_o in [t_new, t_new_e, t_client_new]:
-        feature_ids_t_o = t_o.get_feature_ids(filters={
-            "region_list": [{
-                "contig_id": "kb|g.166819.c.0",
-                "start": 5000,
-                "strand": "?",
-                "length": 5000}]},
-        group_by="region")
-        assert isinstance(feature_ids_t_o, dict)
-        _log.debug(feature_ids_t_o)
-        assert len(feature_ids_t_o["by_region"]["kb|g.166819.c.0"]["+"]) > 0
-        assert len(feature_ids_t_o["by_region"]["kb|g.166819.c.0"]["-"]) > 0
-        _log.debug("Output {}".format(len(feature_ids_t_o)))
-
-
-@skipUnless(shared.can_connect, 'Cannot connect to workspace')
 def test_get_feature_ids_subset_new():
     _log.debug("Input {}".format(genome_new))
     for t_o in [t_new, t_new_e, t_client_new]:


### PR DESCRIPTION
Now all region queries must specify either '+' or '-' strand, which will be less confusing.