### PR TITLE
Separate out check_mk check scripts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,14 @@ deploy-lib:
 	virtualenv $(SERVICE_DIR)/venv
 	. $(SERVICE_DIR)/venv/bin/activate && pip install .
 
+# to do: automate symlink creation
 deploy-service-scripts:
 	cp $(SCRIPTS_DIR)/start_service $(SCRIPTS_DIR)/stop_service $(SERVICE_DIR)/
 	mkdir -p $(SERVICE_DIR)/check_mk
 	cp $(SCRIPTS_DIR)/data_api_service $(SERVICE_DIR)/check_mk/
+	ln -s $(SERVICE_DIR)/check_mk/data_api_service $(SERVICE_DIR)/check_mk/taxon_api_service
+	ln -s $(SERVICE_DIR)/check_mk/data_api_service $(SERVICE_DIR)/check_mk/assembly_api_service
+	ln -s $(SERVICE_DIR)/check_mk/data_api_service $(SERVICE_DIR)/check_mk/genome_annotation_api_service
 
 test: subupdate shutdown startup
 	@echo '+- Run nosetests from the data_api source directory, which will use the test data'

--- a/scripts/data_api_service
+++ b/scripts/data_api_service
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-script_dir=$(dirname "$(readlink -f "$0")")
+# This script is used to check the status of the various data_api services.
+# It determines which service to check based on the name of the symlink. So do
+# ln -s data_api_service $servicename_api_service
+# to check $servicename.  (The Makefile does this for taxon, assembly, and genome_annotation.)
 
-logfile=$script_dir/log
+script_dir=$(dirname "$(readlink -f "$0")")
+service=$(basename $0 | perl -ne '($service)= $_=~/(.*)_api_service$/;print $service')
+
+logfile=$script_dir/$service.log
 
 rm -f $logfile
 
@@ -49,9 +55,6 @@ source $script_dir/../venv/bin/activate
 export KB_AUTH_TOKEN=$(cat /etc/check_mk/dataapitoken)
 
 date >> $logfile
-echo checking services from $KB_DEPLOYMENT_CONFIG in $deployenv >> $logfile
+echo checking $service from $KB_DEPLOYMENT_CONFIG in $deployenv >> $logfile
 
-for api in assembly taxon genome_annotation
-do
-    test_api_service.py $api https://$deployenv.kbase.us/services/data/$api 2>> $logfile
-done
+test_api_service.py $service https://$deployenv.kbase.us/services/data/$service 2>> $logfile


### PR DESCRIPTION
Make the scripts for checking each data_api service a separate script, so that if one gets stuck the other services can still be checked properly.