### PR TITLE
Stress testing and bugfix

### DIFF
--- a/bin/data_api_start_service.py
+++ b/bin/data_api_start_service.py
@@ -172,8 +172,8 @@ def main():
                         required=True)
     parser.add_argument("--port", help="port to listen on", type=int)
     parser.add_argument("--kbase_url",
-                        help="prod, next, ci, localhost, dir_cache, dir_nocache",
-                        default="dir_nocache")
+                        help="prod, next, ci, localhost, dir_cache, dir_nocache "
+                        "default=(dir_nocache)", default="dir_nocache")
     parser.add_argument("--pidfile", help="path to pidfile to use")
     parser.add_argument("--kill-on-exit", action="store_true", default=False,
                         dest="kill_on_exit",

--- a/bin/stress_service.py
+++ b/bin/stress_service.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import multiprocessing
+from six import print_
+import sys
+import time
+
+import doekbase.data_api
+#from doekbase.data_api.taxonomy.taxon.api import TaxonClientAPI
+from doekbase.data_api.annotation.genome_annotation.api import GenomeAnnotationClientAPI
+from doekbase.data_api.sequence.assembly.api import AssemblyClientAPI
+from doekbase.workspace.client import Workspace
+
+PORTS = {
+    'taxon': 9101,
+    'assembly': 9102,
+    'genome_annotation': 9103
+}
+
+token = os.environ["KB_AUTH_TOKEN"]
+
+workspace_names = ["ReferenceEnsemblPlantGenomeAnnotations", "ReferenceGenomeAnnotations"]
+
+def get_genome_annotation_url(host):
+    return "http://{shost}:{port}".format(shost=host, port=PORTS['genome_annotation'])
+
+def get_assembly_url(host):
+    return "http://{shost}:{port}".format(shost=host, port=PORTS['assembly'])
+
+def get_workspace_url(host):
+    return "https://{khost}.kbase.us/services/ws/".format(khost=host)
+
+def run(service_host, kbase_host):
+    pid = os.getpid()
+    ws = Workspace(url=get_workspace_url(kbase_host), token=token)
+    for name in workspace_names:
+
+        while 1:
+            print('[{:d}] List objects'.format(pid))
+            try:
+                annotations = ws.list_objects({"workspaces": [name], "type": "KBaseGenomeAnnotations.GenomeAnnotation"})
+                break
+            except Exception as err:
+                print('Retry on timeout: {}'.format(str(err)))
+
+        print('[{:d}] Got {:d} objects'.format(pid, len(annotations)))
+        for obj_num, obj in enumerate(annotations):
+            ref = obj[7] + "/" + obj[1]
+            print('[{:d}] Fetch {:d}/{:d}: {}'.format(pid, obj_num +1, len(annotations), ref))
+            ga = GenomeAnnotationClientAPI(get_genome_annotation_url(service_host),token,ref)
+            #taxon = TaxonClientAPI(services["taxon_service_url"],token,ga.get_taxon())
+            assembly = AssemblyClientAPI(get_assembly_url(service_host), token, ga.get_assembly())
+            while 1:
+                try:
+                    fids = ga.get_feature_ids()
+                    fdata = ga.get_features()
+                    cids = assembly.get_contig_ids()
+                    contigs = assembly.get_contigs()
+                except doekbase.data_api.exceptions.ServiceError as err:
+                    print('[{:d}] Error: {}'.format(pid, err))
+                    time.sleep(0.5)
+                    print('[{:d}] Retrying'.format(pid))
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', dest='shost', help='service host (localhost)', default='localhost',
+                        metavar='HOST')
+    parser.add_argument('-k', dest='khost', help='kbase host (ci)', default='ci', metavar='HOST')
+    parser.add_argument('-p', dest='par', help='run in parallel N times', default=1, metavar='N',
+                        type=int)
+    args = parser.parse_args()
+    if args.par < 2:
+        run(args.shost, args.khost)
+    else:
+        processes = []
+        print_('start {} processes'.format(args.par))
+        for i in range(args.par):
+            print_('.', end='\r')
+            process = multiprocessing.Process(target=run, args=(args.shost, args.khost))
+            process.start()
+            processes.append(process)
+        print_('\njoin processes')
+        for process in processes:
+            print_('.', end='\r')
+            process.join()
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/lib/doekbase/data_api/service_core.py
+++ b/lib/doekbase/data_api/service_core.py
@@ -56,7 +56,8 @@ def server_method(func):
         assert hasattr(self, 'ttypes'), 'Method in wrapped class must have ' \
                                         '"ttypes" attribute'
         error, result = None, None
-        self.log.debug('method={meth} state=begin token={tok} ref={ref} args={'
+        #self.log.debug('method={meth} state=begin token={tok} ref={ref} args={'
+        self.log.debug('method={meth} state=begin ref={ref} args={'
                        'args} kwargs={kw}'
                        .format(meth=func.__name__, tok=token, ref=ref,
                                args=args, kw=kwargs))
@@ -65,33 +66,35 @@ def server_method(func):
             result = func(self, token, ref, *args, **kwargs)
         except AttributeError, e:
             error = e
-            raise self.ttypes.AttributeException(e.message,
+            raise self.ttypes.AttributeException(str(e.message),
                                                  traceback.format_exc())
         except exceptions.AuthenticationError, e:
             error = e
-            raise self.ttypes.AuthenticationException(e.message,
+            raise self.ttypes.AuthenticationException(str(e.message),
                                                       traceback.format_exc())
         except exceptions.AuthorizationError, e:
             error = e
-            raise self.ttypes.AuthorizationException(e.message,
+            raise self.ttypes.AuthorizationException(str(e.message),
                                                      traceback.format_exc())
         except TypeError, e:
             error = e
-            raise self.ttypes.TypeException(e.message, traceback.format_exc())
+            raise self.ttypes.TypeException(str(e.message), traceback.format_exc())
         except Exception, e:
             error = e
-            raise self.ttypes.ServiceException(e.message,
+            raise self.ttypes.ServiceException(str(e.message),
                                                traceback.format_exc(),
                                                {"ref": str(ref)})
         finally:
             if error is None:
-                self.log.debug('method={meth} state=end token={tok} ref={ref} '
+                #self.log.debug('method={meth} state=end token={tok} ref={ref} '
+                self.log.debug('method={meth} state=end ref={ref} '
                                'args={args} kwargs={kw} dur={t:.3f}'
                                .format(meth=func.__name__, tok=token, ref=ref,
                                        args=args, kw=kwargs,
                                        t=time.time() - t0))
             else:
-                self.log.error('method={meth} state=error token={tok} '
+                #self.log.error('method={meth} state=error token={tok} '
+                self.log.error('method={meth} state=error '
                                'ref={ref} args={args} kwargs={kw}'
                                'error_message="{m}" dur={t:.3f}'
                                .format(meth=func.__name__, tok=token, ref=ref,


### PR DESCRIPTION
Added stress test, revised from MH version, to bin

**Important**: Bugfix for returned exception in wrapper method from service_core, make sure it is always a string otherwise Thrift may choke

took user-token out of some debug messages (it was ugly)

improved `-h` output for data_api_start_service.py