### PR TITLE
fix stacktrace on missing function

### DIFF
--- a/lib/doekbase/data_api/annotation/genome_annotation/api.py
+++ b/lib/doekbase/data_api/annotation/genome_annotation/api.py
@@ -895,7 +895,7 @@ class _KBaseGenomes_Genome(ObjectAPI, GenomeAnnotationInterface):
             f = {}
             f["feature_id"] = x['id']
             f["feature_type"] = x['type']
-            f["feature_function"] = x['function']
+            f["feature_function"] = x.get('function', '')
 
             if "location" in x:
                 f["feature_locations"] = [{"contig_id": loc[0],


### PR DESCRIPTION
This is causing the GA feature table to break due to a service stacktrace, e.g. for:

https://narrative-ci.kbase.us/#dataview/544/Arabidopsis_thaliana