### PR TITLE
Literal include mechanism for Thrift specs

### DIFF
--- a/bin/data_api_preprocess_thrift
+++ b/bin/data_api_preprocess_thrift
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+"""
+Pre-process Thrift scripts
+"""
+__author__ = 'Dan Gunter <dkgunter@lbl.gov>'
+__date__ = '4/5/16'
+
+import argparse
+import glob
+import logging
+import os
+import sys
+#
+from doekbase.data_api import thrift_include
+
+_log = logging.getLogger('kbase.preprocess')
+_hnd = logging.StreamHandler()
+_hnd.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+_log.addHandler(_hnd)
+
+def main(cmdline):
+    cwd = os.path.dirname(os.path.abspath(__file__))
+    parser = argparse.ArgumentParser(
+        description='Update Thrift specs in all'
+                    'specified files and directories with includes')
+    parser.add_argument('--include', '-I', dest='includes', action='append', default=[],
+                        help='Directory with .thrift files to include ("." if none given)')
+    parser.add_argument('--verbose', '-v', dest='vb', action="count", default=0,
+                        help="Print more verbose messages to standard error. "
+                             "Repeatable. (default=ERROR)")
+    parser.add_argument('path', action='append', default=[])
+    args = parser.parse_args(cmdline)
+    verbosity = (logging.ERROR, logging.INFO, logging.DEBUG)[min(args.vb, 2)]
+    _log.setLevel(verbosity)
+
+    changed, unchanged = preprocess(get_file_list(args.path), args.includes)
+
+    if len(changed) == 0:
+        print('No files changed')
+    else:
+        n = len(changed)
+        print('{num:d} file{plural} changed: {f}'.format(
+            num=n, f=make_comma_list(changed), plural='s' if n > 1 else ''))
+    if len(unchanged) > 0:
+        n = len(unchanged)
+        print('{num:d} file{plural} unchanged: {f}'.format(
+            num=n, f=make_comma_list(unchanged), plural='s' if n > 1 else ''))
+    return 0
+
+def make_comma_list(items):
+    sorted_items = sorted(list(items))
+    return ', '.join(sorted_items)
+
+def preprocess(file_list, includes):
+    if len(file_list) == 0:
+        _log.warn('No files to process')
+        return
+    _log.info('process-file-list.begin count={:d}'.format(len(file_list)))
+    changed_files, unchanged_files = set(), set()
+    for filename in file_list:
+        fp = open(filename, 'r+')
+        preprocessor = thrift_include.ThriftPP(include_paths=includes, read_file=fp,
+                                               write_file=fp)
+        _log.debug('process-file.begin file={}'.format(fp.name))
+        changed = False
+        try:
+            changed = preprocessor.process()
+        except IOError as err:
+            print('Error opening file: {}'.format(err))
+            break
+        except thrift_include.IncludedFileNotFound as err:
+            print('Error with include: {}'.format(err))
+            break
+        _log.debug('process-file.end file={} was-changed={}'.format(fp.name, changed))
+        if not changed:
+            unchanged_files.add(filename)
+        changed_files = changed_files.union(set(preprocessor.get_changed_files()))
+    _log.info('process-file-list.end count={:d} changed={}'.format(len(file_list),
+                                                                   changed))
+    return changed_files, unchanged_files
+
+def get_file_list(path_args):
+    files = []
+    for path in path_args:
+        if os.path.isdir(path):
+            path_had_files = False
+            for filename in glob.glob(os.path.join(path, '*.thrift')):
+                files.append(filename)
+                path_had_files = True
+            if not path_had_files:
+                _log.warn('No files found in path={}'.format(path))
+        else:
+            files.append(path)
+    return files
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/lib/doekbase/data_api/tests/test_thrift_include.py
+++ b/lib/doekbase/data_api/tests/test_thrift_include.py
@@ -1,0 +1,97 @@
+"""
+Tests for the thrift_include module
+"""
+import logging
+import os
+import shutil
+import tempfile
+from doekbase.data_api.tests import shared
+from doekbase.data_api import exceptions
+from doekbase.data_api import thrift_include
+
+_log = logging.getLogger(__name__)
+
+def setup():
+    shared.setup()
+
+input_files = {
+    'A':"""File A
+#%include B
+  #%include C
+Some stuff here
+
+#%include D
+goodbye""",
+    'B': "Hello from File B",
+    'C': "Hello from File C",
+    'D': """Hello from File D..
+Here is file E:
+#%include E
+More of file D.
+""",
+    'E': "Hello from File E"
+}
+
+expected_output = """File A
+#%include B
+{B}
+#%endinclude B
+#%include C
+{C}
+#%endinclude C
+Some stuff here
+
+#%include D
+Hello from File D..
+Here is file E:
+{E}
+More of file D.
+#%endinclude D
+goodbye""".format(**input_files)
+
+class TemporaryDirectory(object):
+    def __init__(self):
+        self._d = None
+    def __enter__(self):
+        self._d = tempfile.mkdtemp()
+        return self._d
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._d is not None:
+            shutil.rmtree(self._d)
+        self._d = None
+
+def _test_include(in_place=None):
+    with TemporaryDirectory() as tmpdirname:
+        print("Temporary directory: {}".format(tmpdirname))
+        # create input files
+        for filename, contents in input_files.items():
+            f = open(os.path.join(tmpdirname, filename), 'w')
+            f.write(contents)
+            f.close()
+
+        # preprocess the root input file
+        a = open(os.path.join(tmpdirname, 'A'), 'r+')
+        if not in_place:
+
+        pp = thrift_include.ThriftPP(read_file=a, write_file=a, include_paths=[tmpdirname])
+        changed = pp.process()
+        assert changed
+        a.close()
+
+        # check the content
+        a = open(os.path.join(tmpdirname, 'A'), 'r')
+        got_lines = a.readlines()
+        _log.debug("Got {:d}:\n{}".format(len(got_lines), ''.join(got_lines)))
+
+        expected_lines = expected_output.split('\n')
+        _log.debug("Expected {:d}:\n{}".format(len(expected_lines), '\n'.join(expected_lines)))
+        assert len(got_lines) == len(expected_lines)
+
+        for got, expected in zip(got_lines, expected_lines):
+            assert got.strip() == expected.strip()
+
+def test_include_in_place():
+    _test_include(in_place=True)
+
+def test_include_copy():
+    _test_include(in_place=False)

--- a/lib/doekbase/data_api/thrift_include.py
+++ b/lib/doekbase/data_api/thrift_include.py
@@ -1,0 +1,198 @@
+"""
+Pre-process Thrift scripts
+
+This processes include statements of the form:
+
+#%include foobar foo/bar.thrift
+
+"""
+__author__ = 'Dan Gunter <dkgunter@lbl.gov>'
+__date__ = '4/5/16'
+
+import logging
+
+_log = logging.getLogger('kbase.preprocess')
+import os
+import re
+
+class ThriftPPException(Exception):
+    pass
+
+class FileNotFound(ThriftPPException):
+    pass
+
+class IncludedFileNotFound(ThriftPPException):
+    def __init__(self, source, filename, linenum):
+        msg = 'Cannot find file "{}" included from {}:{}'.format(filename, source, linenum)
+        ThriftPPException.__init__(self, msg)
+
+class ThriftPP(object):
+    """Thrift pre-processor.
+    """
+    INC_START = re.compile('#\s*%include\s+(\S+)')
+    INC_END_PREFIX = '#%endinclude'
+    INC_END = re.compile(INC_END_PREFIX)
+    INC_END_MARKER = INC_END_PREFIX + ' {label}'
+
+    def __init__(self, include_paths=None, read_file=None, write_file=None, included=None):
+        """Create, but do not scan paths and files until :meth:`process` is called.
+
+        Args:
+            include_paths (list[str]): Paths for included files
+            read_file (file): Input file
+            write_file (file): Output file (may be same object as read_file)
+            included (set): Already included paths (to avoid loops)
+        Raises:
+            ThriftPPException if thrift_file is empty
+        """
+
+        self._paths = include_paths or os.getcwd()
+        self._rfile, self._wfile = read_file, write_file
+        self._included = included or set()
+        self._included.add(read_file.name)
+        self._files_changed = set()
+
+    def process(self):
+        """Process thrift file and include paths.
+
+        Returns:
+            True if changed, False otherwise
+
+        Raises:
+            IOError if main file cannot be opened
+            IncludedFileNotFound if included file cannot be opened
+        """
+        if self._rfile.closed:
+            raise IOError('Input file {} is closed'.format(self._rfile.name))
+
+        contents = self._scan()
+        new_contents = self._update(contents)
+        changed = contents != new_contents
+        if changed or self._rfile is not self._wfile:
+            self._replace(new_contents)
+            self._files_changed.add(self._wfile.name)
+        return changed
+
+    def close(self):
+        """Close all open files.
+        """
+        self._rfile.close()
+        self._wfile.close()
+
+    def get_changed_files(self):
+        """Get list of all files changed, directly or indirectly.
+        """
+        return list(self._files_changed)
+
+    def _scan(self):
+        return [s.strip() for s in self._rfile.readlines()]
+
+    def _update(self, lines):
+        """Update the contents.
+        This processes any includes.
+
+        Raises:
+            IncludedFileNotFound
+        """
+        result = []
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            result.append(line)
+            _log.debug('process line="{}"'.format(line))
+            # look for a special include-start line
+            match = self.INC_START.match(line)
+            if match:
+                _log.debug('match line={}'.format(line))
+                filename = match.group(1)
+                label = '{}'.format(filename)
+                # read replacement from the file
+                try:
+                    replacement = self._read_include(filename)
+                except FileNotFound:
+                    raise IncludedFileNotFound(self._rfile.name, filename, i+1)
+                result.extend(replacement)
+                # look for end of included section
+                end_pos = self._find_end(label, lines, i + 1)
+                if end_pos > 0:
+                    _log.debug("skip to={}".format(end_pos))
+                    # if found, jump past older version of include
+                    i = end_pos
+                else:
+                    # append an end marker for next time
+                    result.append(self.INC_END_MARKER.format(label=label))
+                    i += 1
+            else:
+                # move to next line of input
+                i += 1
+        return result
+
+    def _read_include(self, filename):
+        if filename in self._included:
+            _log.warn('circular-include file={}'.format(filename))
+            return []
+        # recursively include
+        path = self._find_included_file(filename)
+        if path is None:
+            raise FileNotFound(filename)
+        fp = file(path, 'r+')
+        child_inc = ThriftPP(include_paths=self._paths, read_file=fp,
+                             write_file=fp, included=self._included)
+        changed = child_inc.process()
+        if changed:
+            self._files_changed.add(path)
+        child_inc.close()
+        # return include-processed file, dropping include/end-include markers
+        lines = []
+        for line in file(path).readlines():
+            if not (self.INC_START.match(line) or self.INC_END.match(line)):
+                lines.append(line.strip())
+        return lines
+
+    def _find_included_file(self, filename):
+        if os.path.exists(filename):
+            return filename
+        if not os.path.isabs(filename):
+            for include_path in self._paths:
+                inc_filename = os.path.join(include_path, filename)
+                if os.path.exists(inc_filename):
+                    return inc_filename
+        return None
+
+    def _find_end(self, label, lines, pos):
+        pattern = re.compile(self.INC_END_MARKER.format(label=label))
+        i = pos
+        found = -1
+        while i < len(lines):
+            if pattern.match(lines[i]):
+                found = i
+                break
+            i += 1
+        return found
+
+    def _replace(self, lines):
+        if self._wfile.closed:
+            raise IOError('Output file {} is closed'.format(self._wfile.name))
+        if self._rfile is self._wfile:
+            self._wfile.seek(0)
+            self._wfile.truncate()
+        for line in lines:
+            self._wfile.write(line + '\n')
+
+## tests
+
+
+def test_basic():
+    print("Run test_basic")
+    if not os.path.exists('foo.txt'):
+        f = open('foo.txt', 'w')
+        for s in ['line 1', 'line 2', '//%include foo', 'line 3']:
+            f.write(s + '\n')
+        f.close()
+    f = open('foo.txt', 'r+')
+    pp = ThriftPP(read_file=f, write_file=f)
+    pp.process()
+    f.seek(0)
+    for i, line in enumerate(f):
+        print("{:3d}: {}".format(i + 1, line[:-1]))
+    pp.close()

--- a/run-tests-local.sh
+++ b/run-tests-local.sh
@@ -1,4 +1,18 @@
 #!/bin/sh
+# check for test resource
+if [ ! -e test_resources -o ! -d test_resources ]; then
+    printf "Abort: Directory 'test_resources/' missing (or not a directory)\n"
+    exit 1
+fi
+num_files=$(ls -l test_resources | wc -l)
+if [ $num_files -eq 0 ]; then
+    printf "Abort: Directory 'test_resources/' is empty\n"
+    printf "You can check it out from git with this command:\n"
+    printf "    git submodule update --init\n"
+    exit 2
+fi
+
+# start services
 data_api_start_service.py --config deployment.cfg --service taxon --port 9101  >taxon.out 2>&1 &
 data_api_start_service.py --config deployment.cfg --service assembly --port 9102 >assembly.out 2>&1 &
 data_api_start_service.py --config deployment.cfg --service genome_annotation --port 9103 >ga.out 2>&1 &


### PR DESCRIPTION
Thrift has an include mechanism, but that changes the namespaces for the stubs and libraries. This include mechanism does a literal include of the text, so everything is in the same namespace as before. You can basically break files up into arbitrary chunks and recombine them.

It has two main features that make it more than "10 lines of python":
1. Idempotency. The first time, the "#%include file.thrift" lines are replaced with a block that contains "file.thrift". After that, the block is recognized as already including the file, and its contents are updated. The result is that you can run the preprocessor as many times you want on the same set of files and it will just "do the right thing".
2. Recursion. Included files can include other files. The sub-file will not be modifie in any way, but the results of the nested inclusion will be pasted in the top-level include block in the top-level file.

Note that this commit **does not change any thrift specs to use this include mechanism**. The idea is that it is cleaner to do this in a separate follow-on PR.
