### PR TITLE
Genome name changes and some metadata

### DIFF
--- a/lib/doekbase/data_api/converters/base.py
+++ b/lib/doekbase/data_api/converters/base.py
@@ -89,6 +89,10 @@ class Converter(object):
         """
         pass
 
+    @property
+    def metadata(self):
+        return self.api_obj.object_metadata
+
     def get_target_name(self):
         """Form the target object name from the source name of `self.api_obj`.
         Uses class variable `target_suffix` to form the new name.
@@ -171,3 +175,56 @@ class Converter(object):
         return self.api_obj.get_data_subset([name]).get(name, default)
 
 
+class GenomeName(object):
+    """Pick a proper name for uploaded or converted genome data.
+    """
+    # Configure with these prefixes/codes
+    annotation_type = 'annotation'
+    assembly_type = 'assembly'
+    old_annotation_type = 'genome'
+    old_assembly_type = 'contigset'
+    legacy = 'legacy'
+    legacy_prefix = False # false means suffix
+
+    def __init__(self, base_name, source=None):
+        """Ctor.
+
+        Args:
+            base_name (str): Base name, from user or uploader
+            source (str or None): If not None, the source to add to name
+        """
+        self._kw = {'name': base_name}
+        if source is None:
+            self._base_format = '{name}_{type}'
+        else:
+            self._base_format = '{name}_{source}_{type}'
+            self._kw['source'] = source
+
+    def get_assembly(self):
+        """Get name for Assembly object."""
+        return self._base_format.format(type=self.assembly_type, **self._kw)
+
+
+    def get_genome_annotation(self):
+        """Get name for GA object."""
+        return self._base_format.format(type=self.annotation_type, **self._kw)
+
+
+    def get_contigset(self):
+        """Get name for ContigSet object."""
+        if self.legacy_prefix:
+            name_format = '{old}_' + self._base_format
+        else:
+            name_format = self._base_format + '_{old}'
+        return name_format.format(old=self.legacy,
+                                  type=self.old_assembly_type, **self._kw)
+
+    def get_genome(self):
+        """Get name for Genome object."""
+        if self.legacy_prefix:
+            name_format = '{old}_' + self._base_format
+        else:
+            name_format = self._base_format + '_{old}'
+        return name_format.format(old=self.legacy,
+                                  type=self.old_annotation_type,
+                                  **self._kw)

--- a/lib/doekbase/data_api/converters/genome.py
+++ b/lib/doekbase/data_api/converters/genome.py
@@ -371,7 +371,8 @@ class AssemblyConverter(base.Converter):
         """
         return self._upload_to_workspace(data=contig_set, target_ws=target_ws,
                                          type_=contigset_type,
-                                         target_name=self.get_target_name())
+                                         target_name=self.get_target_name(),
+                                         metadata=self.metadata)
 
     @property
     def md5(self):

--- a/lib/doekbase/data_api/converters/genome.py
+++ b/lib/doekbase/data_api/converters/genome.py
@@ -75,8 +75,9 @@ class GenomeConverter(base.Converter):
         self.proteins = self.api_obj.get_proteins()
         if contigset_ref is None:
             contigset_ref = self._create_contigset(assembly, workspace_name)
+        self.target_name = base.GenomeName(self.object_name).get_genome()
         genome = {
-            'id': self.get_target_name(), #self.external_source_id,
+            'id': self.target_name, #self.external_source_id,
             'scientific_name': taxon.get_scientific_name(),
             'domain': taxon.get_domain(),
             'genetic_code': taxon.get_genetic_code(),
@@ -197,7 +198,7 @@ class GenomeConverter(base.Converter):
         INFO('Uploading object to workspace "{}"'.format(target_ws))
         return self._upload_to_workspace(
             data=data, type_=genome_type,
-            target_name=self.get_target_name(),
+            target_name=self.target_name,
             target_ws=target_ws)
 
     # Object property accessors
@@ -274,9 +275,10 @@ class AssemblyConverter(base.Converter):
         # Construct top-level metadata
         a = self.api_obj # local alias
         asm_id = a.get_assembly_id()
+        self.target_name = base.GenomeName(self.object_name).get_contigset()
         contig_set_dict = {
             'id': asm_id,
-            'name': self.get_target_name(),
+            'name': self.target_name,
             'md5': self.md5,
             'source_id': self.external_source_id,
             'source': self.external_source,
@@ -369,10 +371,10 @@ class AssemblyConverter(base.Converter):
         Returns:
             (str) Workspace reference for created object
         """
+        object_name = self.object_name
         return self._upload_to_workspace(data=contig_set, target_ws=target_ws,
                                          type_=contigset_type,
-                                         target_name=self.get_target_name(),
-                                         metadata=self.metadata)
+                                         target_name=self.target_name)
 
     @property
     def md5(self):

--- a/lib/doekbase/data_api/tests/test_converters.py
+++ b/lib/doekbase/data_api/tests/test_converters.py
@@ -9,10 +9,11 @@ __date__ = '5/26/16'
 
 # Stdlib
 import logging
-from unittest import SkipTest
+from unittest import SkipTest, TestCase
 # Local
 from . import shared
 from doekbase.data_api.converters import genome
+from doekbase.data_api.converters.base import GenomeName
 
 # Target workspace in CI environment
 TEST_CI_WS_NAME = "Converter-Test-Narrative"
@@ -34,8 +35,11 @@ def setup():
     if g_can_connect is None:
         shared._log.info('Trying to connect to "{}" workspace for objects: {}, {}'.format(
             g_kbase_instance, TEST_CI_ASM_OBJID, TEST_CI_GA_OBJID))
-        g_can_connect = shared.can_connect(ref=TEST_CI_ASM_OBJID, deployment_config=g_kbase_instance) and \
-                     shared.can_connect(ref=TEST_CI_GA_OBJID, deployment_config=g_kbase_instance)
+        try:
+            g_can_connect = shared.can_connect(ref=TEST_CI_ASM_OBJID, deployment_config=g_kbase_instance) and \
+                         shared.can_connect(ref=TEST_CI_GA_OBJID, deployment_config=g_kbase_instance)
+        except:
+            pass
         if not g_can_connect:
             shared._log.warn('Cannot connect to "{}" workspace'.format(g_kbase_instance))
 
@@ -86,3 +90,58 @@ def test_assembly_convert():
     result = obj.convert(TEST_CI_WS_ID)
     assert(result)
 
+################################################################
+# Utility functions
+################################################################
+
+class GenomeNameTests(TestCase):
+    def test_demo(self):
+        base = '1234'
+        source = 'refseq'
+        print('With base={} and source={}:'.format(base, source))
+        gn = GenomeName(base, source)
+        print('GenomeAnnotation: {}'.format(gn.get_genome_annotation()))
+        print('Assembly: {}'.format(gn.get_assembly()))
+        print('Genome: {}'.format(gn.get_genome()))
+        print('ContigSet: {}'.format(gn.get_contigset()))
+
+    def test_genome_name_nosource_new(self):
+        base = 'foobar'
+        gn = GenomeName(base)
+        assert base in gn.get_assembly()
+        assert GenomeName.legacy not in gn.get_assembly()
+        assert base in gn.get_genome_annotation()
+        assert GenomeName.legacy not in gn.get_genome_annotation()
+        if GenomeName.annotation_type:
+            assert GenomeName.annotation_type in gn.get_genome_annotation()
+        else:
+            assert not gn.get_genome_annotation().endswith('_genomeannotation')
+            assert not gn.get_genome_annotation().endswith('_annotation')
+
+    def test_genome_name_source_new(self):
+        base, src = 'foobar', 'yomama'
+        gn = GenomeName(base, source=src)
+        assert base in gn.get_assembly()
+        assert src in gn.get_assembly()
+        assert GenomeName.legacy not in gn.get_assembly()
+        assert base in gn.get_genome_annotation()
+        assert src in gn.get_genome_annotation()
+        assert GenomeName.legacy not in gn.get_genome_annotation()
+
+    def test_genome_name_nosource_old(self):
+        base = 'foobar'
+        gn = GenomeName(base)
+        assert base in gn.get_contigset()
+        assert GenomeName.legacy in gn.get_contigset()
+        assert base in gn.get_genome()
+        assert GenomeName.legacy in gn.get_genome()
+
+    def test_genome_name_source_old(self):
+        base, src = 'foobar', 'yomama'
+        gn = GenomeName(base, source=src)
+        assert base in gn.get_contigset()
+        assert src in gn.get_contigset()
+        assert GenomeName.legacy in gn.get_contigset()
+        assert base in gn.get_genome()
+        assert src in gn.get_genome()
+        assert GenomeName.legacy in gn.get_genome()

--- a/lib/doekbase/data_api/tests/test_genome_name.py
+++ b/lib/doekbase/data_api/tests/test_genome_name.py
@@ -1,0 +1,6 @@
+"""
+Description.
+"""
+__author__ = 'Dan Gunter <dkgunter@lbl.gov>'
+__date__ = '6/8/16'
+

--- a/lib/doekbase/data_api/tests/test_genome_name.py
+++ b/lib/doekbase/data_api/tests/test_genome_name.py
@@ -1,6 +1,0 @@
-"""
-Description.
-"""
-__author__ = 'Dan Gunter <dkgunter@lbl.gov>'
-__date__ = '6/8/16'
-


### PR DESCRIPTION
Several changes related to usability
- converted genome/assembly naming in converters/base/GenomeName
- added metadata blurb for converted objects that would, with some spec changes, show up in the data panel
- probably something else I'm forgetting
