### PR TITLE
fix missing semicolon for CDS Parent field

### DIFF
--- a/lib/doekbase/data_api/annotation/genome_annotation/api.py
+++ b/lib/doekbase/data_api/annotation/genome_annotation/api.py
@@ -2124,7 +2124,7 @@ class _GenomeAnnotation(ObjectAPI, GenomeAnnotationInterface):
                     _log.warn("mRNA {} and gene {} do not have an associated CDS".format(mrna_id, gene_id))
                     return ""
 
-                parent = "Parent={}".format(gene_id)
+                parent = "Parent={};".format(gene_id)
             else:
                 parent = "Parent={};".format(mrna_id)
 


### PR DESCRIPTION
Corrects missing semicolon for Parent field when CDS does not have an associated mRNA
