### PR TITLE
get_referrers() bugfix

### DIFF
--- a/lib/doekbase/data_api/tests/test_converters.py
+++ b/lib/doekbase/data_api/tests/test_converters.py
@@ -17,7 +17,7 @@ from doekbase.data_api.converters.base import GenomeName
 
 # Target workspace in CI environment
 TEST_CI_WS_NAME = "Converter-Test-Narrative"
-TEST_CI_WS_ID = '7609'
+TEST_CI_WS_ID = '8020'
 
 g_kbase_instance = 'ci'
 
@@ -52,7 +52,7 @@ def skip_unless_connect():
 ################################################################
 
 # Input GenomeAnnotation reference object in CI
-TEST_CI_GA_OBJID = '6052/40/1'
+TEST_CI_GA_OBJID = '8020/39/1'
 
 def test_genome_annotation_init():
     """Init GA converter, but don't run convert"""
@@ -73,7 +73,7 @@ def test_genome_annotation_convert():
 # Assembly -> ContigSet
 ################################################################
 
-TEST_CI_ASM_OBJID = '6052/31/1'
+TEST_CI_ASM_OBJID = '8020/30/1'
 
 def test_assembly_init():
     """Init Assembly converter, but don't run convert"""

--- a/lib/doekbase/data_api/tests/test_object_api.py
+++ b/lib/doekbase/data_api/tests/test_object_api.py
@@ -135,9 +135,26 @@ def test_get_data_subset():
 
 
 @skipUnless(shared.can_connect, 'Cannot connect to workspace')
-def test_get_referrers():
+def test_get_referrers_default():
     _log.info("Input {}".format(t))
     referrers = t.get_referrers()
+    _log.info("Output {}".format(referrers))
+
+    all_refs = [x for k in referrers for x in referrers[k]]
+
+    found = set()
+    for x in all_refs:
+        # check to see if there is more than one version of an object
+        r = x.rsplit("/",1)[0]
+
+        assert r not in found
+        found.add(r)
+
+
+@skipUnless(shared.can_connect, 'Cannot connect to workspace')
+def test_get_referrers_all_versions():
+    _log.info("Input {}".format(t))
+    referrers = t.get_referrers(most_recent=False)
     _log.info("Output {}".format(referrers))
 
     assert referrers is not None


### PR DESCRIPTION
- fix for get_referrers() to correctly return only the most recent version of each object
- added test to verify only one instance of each object is included when most_recent=True
- changed test workspace and objects for test_converters
